### PR TITLE
Patch Document module

### DIFF
--- a/insiders/server/documents/karrio/server/documents/generator.py
+++ b/insiders/server/documents/karrio/server/documents/generator.py
@@ -123,7 +123,7 @@ def get_carrier_context(carrier=None):
     display_name = getattr(
         carrier,
         "display_name",
-        REFERENCE_MODELS["carriers"][carrier.carrier_name],
+        REFERENCE_MODELS.get("carriers", {}).get(carrier.carrier_name),
     )
 
     return {

--- a/insiders/server/documents/karrio/server/documents/views.py
+++ b/insiders/server/documents/karrio/server/documents/views.py
@@ -1,4 +1,5 @@
 import sys
+import logging
 from django.http import JsonResponse
 from django.urls import re_path
 from django.core.files.base import ContentFile
@@ -7,6 +8,8 @@ from rest_framework import status
 
 from karrio.server.documents import models
 from karrio.server.documents.generator import Documents
+
+logger = logging.getLogger(__name__)
 
 
 class DocumentGenerator(VirtualDownloadView):
@@ -30,6 +33,7 @@ class DocumentGenerator(VirtualDownloadView):
             response["X-Frame-Options"] = "ALLOWALL"
             return response
         except Exception as e:
+            logger.exception(e)
             _, __, exc_traceback = sys.exc_info()
             trace = exc_traceback
             while True:

--- a/insiders/server/documents/setup.py
+++ b/insiders/server/documents/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="karrio.server.documents",
-    version="2022.4",
+    version="2022.4.3",
     description="Multi-carrier shipping API apps module",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
- Update document module carrier info parsing caused by previous changes that replace carrier_name by custom_carrier_name instead of generic.