### PR TITLE
Add FedEx OneRate support

### DIFF
--- a/sdk/extensions/fedex/karrio/providers/fedex/rate.py
+++ b/sdk/extensions/fedex/karrio/providers/fedex/rate.py
@@ -122,7 +122,7 @@ def rate_request(
         Version=VersionId(ServiceId="crs", Major=28, Intermediate=0, Minor=0),
         ReturnTransitAndCommit=True,
         CarrierCodes=None,
-        VariableOptions=None,
+        VariableOptions=(["FEDEX_ONE_RATE"] if options.fedex_one_rate.state else None),
         ConsolidationKey=None,
         RequestedShipment=RequestedShipment(
             ShipTimestamp=lib.to_date(options.shipment_date.state or datetime.now()),

--- a/sdk/extensions/fedex/karrio/providers/fedex/units.py
+++ b/sdk/extensions/fedex/karrio/providers/fedex/units.py
@@ -327,7 +327,7 @@ class ShippingOption(utils.Enum):
     )
     fedex_extra_labor = utils.OptionEnum("EXTRA_LABOR")
     fedex_extreme_length = utils.OptionEnum("EXTREME_LENGTH")
-    fedex_one_rate = utils.OptionEnum("FEDEX_ONE_RATE")
+    fedex_one_rate = utils.OptionEnum("FEDEX_ONE_RATE", bool)
     fedex_flatbed_trailer = utils.OptionEnum("FLATBED_TRAILER")
     fedex_food = utils.OptionEnum("FOOD")
     fedex_freight_guarantee = utils.OptionEnum("FREIGHT_GUARANTEE")


### PR DESCRIPTION
Feel free to refactor if you want to make it more generic than this, I'm still figuring out karrio's codebase. I did test and it works fine with FedEx OneRate. Doing it this way, in VariableOptions, makes FedEx return both OneRate and non-OneRate rates simultaneously, so it's handy that way.