### PR TITLE
add FedEx signature request based on when option is selected

### DIFF
--- a/sdk/extensions/fedex/karrio/providers/fedex/shipment/create.py
+++ b/sdk/extensions/fedex/karrio/providers/fedex/shipment/create.py
@@ -36,7 +36,9 @@ from fedex_lib.ship_service_v26 import (
     ShippingDocumentSpecification,
     CommercialInvoiceDetail,
     ShippingDocumentFormat,
-    PackageSpecialServicesRequested, SignatureOptionDetail, SignatureOptionType,
+    PackageSpecialServicesRequested,
+    SignatureOptionDetail,
+    SignatureOptionType,
 )
 
 import typing

--- a/sdk/extensions/fedex/karrio/providers/fedex/shipment/create.py
+++ b/sdk/extensions/fedex/karrio/providers/fedex/shipment/create.py
@@ -36,6 +36,7 @@ from fedex_lib.ship_service_v26 import (
     ShippingDocumentSpecification,
     CommercialInvoiceDetail,
     ShippingDocumentFormat,
+    PackageSpecialServicesRequested, SignatureOptionDetail, SignatureOptionType,
 )
 
 import typing
@@ -552,7 +553,15 @@ def shipment_request(
                             if any(payload.reference or "")
                             else None
                         ),
-                        SpecialServicesRequested=None,
+                        SpecialServicesRequested=PackageSpecialServicesRequested(
+                            SignatureOptionDetail=SignatureOptionDetail(
+                                OptionType=(
+                                    SignatureOptionType.ADULT
+                                    if options.signature_confirmation
+                                    else SignatureOptionType.SERVICE_DEFAULT
+                                )
+                            ),
+                        ),
                         ContentRecords=None,
                     )
                 ],

--- a/sdk/extensions/fedex/karrio/providers/fedex/shipment/create.py
+++ b/sdk/extensions/fedex/karrio/providers/fedex/shipment/create.py
@@ -559,7 +559,7 @@ def shipment_request(
                             SignatureOptionDetail=SignatureOptionDetail(
                                 OptionType=(
                                     SignatureOptionType.ADULT
-                                    if options.signature_confirmation
+                                    if options.signature_confirmation.state
                                     else SignatureOptionType.SERVICE_DEFAULT
                                 )
                             ),

--- a/sdk/extensions/fedex/tests/fedex/shipment.py
+++ b/sdk/extensions/fedex/tests/fedex/shipment.py
@@ -387,6 +387,11 @@ ShipmentRequestXml = """<tns:Envelope xmlns:tns="http://schemas.xmlsoap.org/soap
                         <v26:CustomerReferenceType>CUSTOMER_REFERENCE</v26:CustomerReferenceType>
                         <v26:Value>#Order 11111</v26:Value>
                     </v26:CustomerReferences>
+                    <v26:SpecialServicesRequested>
+                        <v26:SignatureOptionDetail>
+                            <v26:OptionType>SERVICE_DEFAULT</v26:OptionType>
+                        </v26:SignatureOptionDetail>
+                    </v26:SpecialServicesRequested>
                 </v26:RequestedPackageLineItems>
             </v26:RequestedShipment>
         </v26:ProcessShipmentRequest>
@@ -565,6 +570,11 @@ MasterShipmentRequestXml = """<tns:Envelope xmlns:tns="http://schemas.xmlsoap.or
                         <v26:CustomerReferenceType>CUSTOMER_REFERENCE</v26:CustomerReferenceType>
                         <v26:Value>#Order 11111</v26:Value>
                     </v26:CustomerReferences>
+                    <v26:SpecialServicesRequested>
+                        <v26:SignatureOptionDetail>
+                            <v26:OptionType>SERVICE_DEFAULT</v26:OptionType>
+                        </v26:SignatureOptionDetail>
+                    </v26:SpecialServicesRequested>
                 </v26:RequestedPackageLineItems>
             </v26:RequestedShipment>
         </v26:ProcessShipmentRequest>
@@ -747,6 +757,11 @@ SecondPieceShipmentRequestXml = """<tns:Envelope xmlns:tns="http://schemas.xmlso
                         <v26:CustomerReferenceType>CUSTOMER_REFERENCE</v26:CustomerReferenceType>
                         <v26:Value>#Order 11111</v26:Value>
                     </v26:CustomerReferences>
+                    <v26:SpecialServicesRequested>
+                        <v26:SignatureOptionDetail>
+                            <v26:OptionType>SERVICE_DEFAULT</v26:OptionType>
+                        </v26:SignatureOptionDetail>
+                    </v26:SpecialServicesRequested>
                 </v26:RequestedPackageLineItems>
             </v26:RequestedShipment>
         </v26:ProcessShipmentRequest>


### PR DESCRIPTION
I'm not sure if we should hide the whole `SpecialServicesRequested` when `signature_confirmation=false`, and what `signatureOptionType` we should use, I used ADULT for now.

also, we need to test if it shows the charge in `extra_charges`, for Canada post it doesn't show. 

P.S. I didn't test this code at all, (currently, I didn't figure out how to run it on my local machine)