### PR TITLE
Fix UPS multi parcel individual weight

### DIFF
--- a/sdk/extensions/ups/karrio/providers/ups/rate.py
+++ b/sdk/extensions/ups/karrio/providers/ups/rate.py
@@ -220,11 +220,11 @@ def rate_request(
                         PackageWeight=ups.WeightType(
                             UnitOfMeasurement=ups.CustomerClassificationType(
                                 Code=provider_units.WeightUnit[
-                                    packages.weight_unit
+                                    str(package.weight.unit)
                                 ].value,
                                 Description="Weight",
                             ),
-                            Weight=str(packages.weight.value),
+                            Weight=str(package.weight.value),
                         ),
                         Commodity=None,
                         PackageServiceOptions=None,

--- a/sdk/extensions/ups/karrio/providers/ups/shipment/create.py
+++ b/sdk/extensions/ups/karrio/providers/ups/shipment/create.py
@@ -599,11 +599,11 @@ def shipment_request(
                         PackageWeight=ups.WeightType(
                             UnitOfMeasurement=ups.LabelImageFormatType(
                                 Code=provider_units.WeightUnit[
-                                    packages.weight_unit
+                                    str(package.weight.unit)
                                 ].value,
                                 Description="Weight",
                             ),
-                            Weight=str(packages.weight.value),
+                            Weight=str(package.weight.value),
                         ),
                         Commodity=None,
                         PackageServiceOptions=None,


### PR DESCRIPTION
UPS multi parcel was passing total weight for each parcel resulting in total weight being original total weight x the number of parcels