### PR TITLE
Mark imports and exports from and to EU as dutiable (DHL Express)

### DIFF
--- a/docker/dashboard/.dockerignore
+++ b/docker/dashboard/.dockerignore
@@ -1,15 +1,16 @@
 # Ignore everything
 *
 
-!/public/
-!/karrio/
-!/src/
+!apps/dashboard/public/
+!apps/dashboard/src/
 !/docker/entrypoint
-!/package.json
-!/package-lock.json
-!/sentry.client.config.js
-!/sentry.server.config.js
-!/tsconfig.json
-!/.eslintrc
-!/next.config.js
-!/LICENSE
+!apps/dashboard/.eslintrc
+!apps/dashboard/next.config.js
+!apps/dashboard/package-lock.json
+!apps/dashboard/package.json
+!apps/dashboard/sentry.client.config.js
+!apps/dashboard/sentry.edge.config.js
+!apps/dashboard/sentry.server.config.js
+!apps/dashboard/tsconfig.json
+!packge-lock.json
+!package.json

--- a/docker/dashboard/Dockerfile
+++ b/docker/dashboard/Dockerfile
@@ -7,9 +7,10 @@ RUN apk add --no-cache libc6-compat
 FROM node:21.2.0-alpine3.17 AS builder
 WORKDIR /app
 COPY . .
-RUN npm ci
+RUN npm ci -w apps/dashboard 
 RUN npm run build -w apps/dashboard && \
-  npm install --production --ignore-scripts --prefer-offline
+  rm -rf node_modules && \
+  npm install --omit=dev --ignore-scripts --prefer-offline -w apps/dashboard
 
 # Production image, copy all the files and run next
 FROM node:21.2.0-alpine3.17 AS runner

--- a/modules/connectors/dhl_express/karrio/providers/dhl_express/rate.py
+++ b/modules/connectors/dhl_express/karrio/providers/dhl_express/rate.py
@@ -102,7 +102,14 @@ def rate_request(
         raise errors.DestinationNotServicedError(payload.shipper.country_code)
 
     is_document = all([parcel.is_document for parcel in payload.parcels])
-    is_dutiable = is_international and not is_document
+    is_dutiable = (
+        is_international
+        and not is_document
+        and (
+            units.EUCountry.map(payload.shipper.country_code).value is None
+            or units.EUCountry.map(payload.recipient.country_code).value is None
+        )
+    )
 
     services = lib.to_services(
         payload.services,

--- a/modules/connectors/dhl_express/karrio/providers/dhl_express/shipment.py
+++ b/modules/connectors/dhl_express/karrio/providers/dhl_express/shipment.py
@@ -105,7 +105,7 @@ def shipment_request(
         and not is_document
         and (
             units.EUCountry.map(payload.shipper.country_code).value is None
-            and units.EUCountry.map(payload.recipient.country_code).value is None
+            or units.EUCountry.map(payload.recipient.country_code).value is None
         )
     )
     options = lib.to_shipping_options(

--- a/turbo.json
+++ b/turbo.json
@@ -1,15 +1,22 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalDependencies": ["**/.env.*local"],
+  "globalDependencies": [
+    "**/.env.*local"
+  ],
   "pipeline": {
     "build": {
-      "dependsOn": ["^build"],
-      "outputs": [".next/**", "!.next/cache/**"]
+      "dependsOn": [
+        "^build"
+      ],
+      "outputs": [
+        ".next/**",
+        "!.next/cache/**"
+      ]
     },
     "lint": {},
     "dev": {
       "cache": false,
-      "persistent": true
+      "persistent": false
     }
   }
 }


### PR DESCRIPTION
I am currently trying to set up karrio for our DHL shipments and our DHL contact reports that EU exports are not correctly declared as dutiable.

Since I'm a Ruby guy and don't know much about Python projects and I can't get the development environment to work on my machine, this is unfortunately just a code suggestion without tests. Sorry.

Some background:
* Exports from EU to the world (non-EU) are dutiable.
* Imports from world (non-EU) to EU are dutiable.
* Imports and exports within EU are not dutiable.

