### PR TITLE
fix: allied_express extension required defaults

### DIFF
--- a/modules/connectors/allied_express/karrio/providers/allied_express/rate.py
+++ b/modules/connectors/allied_express/karrio/providers/allied_express/rate.py
@@ -93,9 +93,9 @@ def rate_request(
             for pkg in packages
         ],
         jobStopsP=allied.JobStopsType(
-            companyName=shipper.company_name,
+            companyName=(shipper.company_name or shipper.contact),
             contact=shipper.contact,
-            emailAddress=shipper.email,
+            emailAddress=shipper.email or " ",
             geographicAddress=allied.GeographicAddressType(
                 address1=shipper.address_line1,
                 address2=shipper.address_line2 or " ",
@@ -104,12 +104,12 @@ def rate_request(
                 state=shipper.state_code,
                 suburb=shipper.city,
             ),
-            phoneNumber=shipper.phone_number,
+            phoneNumber=shipper.phone_number or "(00) 0000 0000",
         ),
         jobStopsD=allied.JobStopsType(
-            companyName=recipient.company_name,
+            companyName=(recipient.company_name or recipient.contact),
             contact=recipient.contact,
-            emailAddress=recipient.email,
+            emailAddress=recipient.email or " ",
             geographicAddress=allied.GeographicAddressType(
                 address1=recipient.address_line1,
                 address2=recipient.address_line2 or " ",
@@ -118,7 +118,7 @@ def rate_request(
                 state=recipient.state_code,
                 suburb=recipient.city,
             ),
-            phoneNumber=recipient.phone_number,
+            phoneNumber=recipient.phone_number or "(00) 0000 0000",
         ),
         referenceNumbers=([payload.reference] if any(payload.reference or "") else []),
         serviceLevel=(service.value if service else "R"),

--- a/modules/connectors/allied_express/karrio/providers/allied_express/shipment/create.py
+++ b/modules/connectors/allied_express/karrio/providers/allied_express/shipment/create.py
@@ -84,9 +84,9 @@ def shipment_request(
             for pkg in packages
         ],
         jobStopsP=allied.JobStopsType(
-            companyName=shipper.company_name,
+            companyName=(shipper.company_name or shipper.contact),
             contact=shipper.contact,
-            emailAddress=shipper.email,
+            emailAddress=shipper.email or " ",
             geographicAddress=allied.GeographicAddressType(
                 address1=shipper.address_line1,
                 address2=shipper.address_line2 or " ",
@@ -95,12 +95,12 @@ def shipment_request(
                 state=shipper.state_code,
                 suburb=shipper.city,
             ),
-            phoneNumber=shipper.phone_number,
+            phoneNumber=shipper.phone_number or "(00) 0000 0000",
         ),
         jobStopsD=allied.JobStopsType(
-            companyName=recipient.company_name,
+            companyName=(recipient.company_name or recipient.contact),
             contact=recipient.contact,
-            emailAddress=recipient.email,
+            emailAddress=recipient.email or " ",
             geographicAddress=allied.GeographicAddressType(
                 address1=recipient.address_line1,
                 address2=recipient.address_line2 or " ",
@@ -109,7 +109,7 @@ def shipment_request(
                 state=recipient.state_code,
                 suburb=recipient.city,
             ),
-            phoneNumber=recipient.phone_number,
+            phoneNumber=recipient.phone_number or "(00) 0000 0000",
         ),
         referenceNumbers=([payload.reference] if any(payload.reference or "") else []),
         weight=packages.weight.KG,

--- a/modules/connectors/allied_express/setup.py
+++ b/modules/connectors/allied_express/setup.py
@@ -1,4 +1,3 @@
-
 """Warning: This setup.py is only there for git install until poetry support git subdirectory"""
 from setuptools import setup, find_namespace_packages
 
@@ -7,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="karrio.allied_express",
-    version="2023.12",
+    version="2023.12.1",
     description="Karrio - Allied Express Shipping Extension",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/modules/connectors/allied_express/tests/allied_express/test_rate.py
+++ b/modules/connectors/allied_express/tests/allied_express/test_rate.py
@@ -170,6 +170,7 @@ RateRequest = {
             "state": "WA",
             "suburb": "CANNING VALE",
         },
+        "phoneNumber": "(00) 0000 0000",
     },
     "jobStops_P": {
         "companyName": "TESTING COMPANY",

--- a/modules/connectors/allied_express/tests/allied_express/test_shipment.py
+++ b/modules/connectors/allied_express/tests/allied_express/test_shipment.py
@@ -215,6 +215,7 @@ ShipmentRequest = {
             "state": "WA",
             "suburb": "CANNING VALE",
         },
+        "phoneNumber": "(00) 0000 0000",
     },
     "jobStops_P": {
         "companyName": "TESTING COMPANY",


### PR DESCRIPTION
- (add) meaningful defaults for rate and label generation requests