### PR TITLE
fix: non picked up shipment marked as in-transit

### DIFF
--- a/modules/connectors/fedex/karrio/providers/fedex/tracking.py
+++ b/modules/connectors/fedex/karrio/providers/fedex/tracking.py
@@ -45,11 +45,16 @@ def _extract_tracking(
         or _parse_date_or_timestamp(date_or_timestamps, "ANTICIPATED_TENDER")
         or _parse_date_or_timestamp(date_or_timestamps, "ESTIMATED_DELIVERY")
     )
+    last_event = (
+        track_detail.Events[0].EventType
+        if any(track_detail.Events)
+        else getattr(track_detail.StatusDetail, "Code", "")
+    )
     status = next(
         (
             status.name
             for status in list(provider_units.TrackingStatus)
-            if getattr(track_detail.StatusDetail, "Code", "") in status.value
+            if last_event in status.value
         ),
         provider_units.TrackingStatus.in_transit.name,
     )

--- a/modules/connectors/fedex/karrio/providers/fedex/units.py
+++ b/modules/connectors/fedex/karrio/providers/fedex/units.py
@@ -510,6 +510,7 @@ class DocumentUploadOption(utils.Enum):
 
 class TrackingStatus(utils.Enum):
     on_hold = ["DE", "SE"]
+    pending = ["OC"]
     delivered = ["DL"]
     in_transit = [""]
     delivery_failed = ["CA", "RS"]

--- a/modules/connectors/ups/karrio/providers/ups/units.py
+++ b/modules/connectors/ups/karrio/providers/ups/units.py
@@ -452,6 +452,7 @@ class UploadDocumentType(utils.StrEnum):
 
 class TrackingStatus(utils.Enum):
     on_hold = ["X"]
+    pending = ["MP"]
     delivered = ["D"]
     in_transit = [""]
     delivery_failed = ["RS"]

--- a/modules/core/karrio/server/core/serializers.py
+++ b/modules/core/karrio/server/core/serializers.py
@@ -23,8 +23,8 @@ class ShipmentStatus(utils.Enum):
 class TrackerStatus(utils.Enum):
     pending = "pending"
     unknown = "unknown"
-    delivered = "delivered"
     on_hold = "on_hold"
+    delivered = "delivered"
     in_transit = "in_transit"
     delivery_delayed = "delivery_delayed"
     out_for_delivery = "out_for_delivery"

--- a/modules/sdk/karrio/core/units.py
+++ b/modules/sdk/karrio/core/units.py
@@ -1428,6 +1428,7 @@ class ComputedDocumentFile(models.DocumentFile):
 
 class TrackingStatus(utils.Enum):
     on_hold = ["on_hold"]
+    pending = ["pending"]
     delivered = ["delivered"]
     in_transit = ["in_transit"]
     delivery_failed = ["delivery_failed"]


### PR DESCRIPTION
- (add) pending status to karrio SDK to handle event code when a package hasn't been picked up and can still be cancelled