### PR TITLE
[bug-fix] usps label response parsing

### DIFF
--- a/modules/connectors/usps/setup.py
+++ b/modules/connectors/usps/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="karrio.usps",
-    version="2023.9.2",
+    version="2023.9.13",
     description="Karrio - USPS Shipping extension",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/modules/connectors/usps/tests/usps/test_shipment.py
+++ b/modules/connectors/usps/tests/usps/test_shipment.py
@@ -158,6 +158,7 @@ ShipmentRequestXML = """<eVSRequest USERID="username">
     <AllowNonCleansedOriginAddr></AllowNonCleansedOriginAddr>
     <ToName>Tall Tom</ToName>
     <ToFirm>ABC Corp.</ToFirm>
+    <ToAddress1></ToAddress1>
     <ToAddress2>1098 N Fraser Street</ToAddress2>
     <ToCity>Georgetown</ToCity>
     <ToState>SC</ToState>

--- a/modules/connectors/usps_international/karrio/providers/usps_international/shipment/first_class_mail.py
+++ b/modules/connectors/usps_international/karrio/providers/usps_international/shipment/first_class_mail.py
@@ -24,7 +24,11 @@ def parse_shipment_response(
     settings: provider_utils.Settings,
 ) -> typing.Tuple[models.ShipmentDetails, typing.List[models.Message]]:
     errors = provider_error.parse_error_response(response, settings)
-    details = _extract_details(response, settings)
+    details = (
+        _extract_details(response, settings)
+        if len(lib.find_element("BarcodeNumber", response)) > 0
+        else None
+    )
 
     return details, errors
 
@@ -76,7 +80,7 @@ def shipment_request(
         FromFirstName=customs.signer or shipper.person_name,
         FromLastName=shipper.person_name,
         FromFirm=shipper.company_name or "N/A",
-        FromAddress1=shipper.address_line2,
+        FromAddress1=shipper.address_line2 or "",
         FromAddress2=shipper.street,
         FromUrbanization=None,
         FromCity=shipper.city,
@@ -87,7 +91,7 @@ def shipment_request(
         ToFirstName=recipient.person_name,
         ToLastName=recipient.person_name,
         ToFirm=recipient.company_name or "N/A",
-        ToAddress1=recipient.address_line2,
+        ToAddress1=recipient.address_line2 or "",
         ToAddress2=recipient.street,
         ToAddress3=None,
         ToCity=recipient.city,

--- a/modules/connectors/usps_international/karrio/providers/usps_international/shipment/global_express_guaranteed.py
+++ b/modules/connectors/usps_international/karrio/providers/usps_international/shipment/global_express_guaranteed.py
@@ -20,7 +20,14 @@ def parse_shipment_response(
     response: lib.Element, settings: provider_utils.Settings
 ) -> typing.Tuple[models.ShipmentDetails, typing.List[models.Message]]:
     errors = provider_error.parse_error_response(response, settings)
-    details = _extract_details(response, settings)
+    details = (
+        _extract_details(response, settings)
+        if (
+            len(lib.find_element("USPSBarcodeNumber", response)) > 0
+            or len(lib.find_element("FedExBarcodeNumber", response)) > 0
+        )
+        else None
+    )
 
     return details, errors
 
@@ -73,7 +80,7 @@ def shipment_request(
         FromLastName=shipper.person_name,
         FromFirm=shipper.company_name or "N/A",
         FromAddress1=shipper.street,
-        FromAddress2=shipper.address_line2,
+        FromAddress2=shipper.address_line2 or "",
         FromUrbanization=None,
         FromCity=shipper.city,
         FromState=lib.to_state_name(shipper.state_code, country="US"),
@@ -85,7 +92,7 @@ def shipment_request(
         ToLastName=recipient.person_name,
         ToFirm=recipient.company_name or "N/A",
         ToAddress1=recipient.street,
-        ToAddress2=recipient.address_line2,
+        ToAddress2=recipient.address_line2 or "",
         ToAddress3=None,
         ToPostalCode=recipient.postal_code,
         ToPhone=recipient.phone_number,

--- a/modules/connectors/usps_international/karrio/providers/usps_international/shipment/priority_express.py
+++ b/modules/connectors/usps_international/karrio/providers/usps_international/shipment/priority_express.py
@@ -23,7 +23,11 @@ def parse_shipment_response(
     response: lib.Element, settings: provider_utils.Settings
 ) -> typing.Tuple[models.ShipmentDetails, typing.List[models.Message]]:
     errors = provider_error.parse_error_response(response, settings)
-    details = _extract_details(response, settings)
+    details = (
+        _extract_details(response, settings)
+        if len(lib.find_element("BarcodeNumber", response)) > 0
+        else None
+    )
 
     return details, errors
 
@@ -80,7 +84,7 @@ def shipment_request(
         FromFirstName=customs.signer or shipper.person_name or "N/A",
         FromLastName=shipper.person_name,
         FromFirm=shipper.company_name or "N/A",
-        FromAddress1=shipper.address_line2,
+        FromAddress1=shipper.address_line2 or "",
         FromAddress2=shipper.address_line1,
         FromUrbanization=None,
         FromCity=shipper.city,
@@ -92,7 +96,7 @@ def shipment_request(
         ToFirstName=recipient.person_name,
         ToLastName=recipient.person_name,
         ToFirm=recipient.company_name or "N/A",
-        ToAddress1=recipient.address_line2,
+        ToAddress1=recipient.address_line2 or "",
         ToAddress2=recipient.address_line1,
         ToAddress3=None,
         ToCity=recipient.city,

--- a/modules/connectors/usps_international/karrio/providers/usps_international/shipment/priority_mail.py
+++ b/modules/connectors/usps_international/karrio/providers/usps_international/shipment/priority_mail.py
@@ -25,7 +25,11 @@ def parse_shipment_response(
     settings: provider_utils.Settings,
 ) -> typing.Tuple[models.ShipmentDetails, typing.List[models.Message]]:
     errors = provider_error.parse_error_response(response, settings)
-    details = _extract_details(response, settings)
+    details = (
+        _extract_details(response, settings)
+        if len(lib.find_element("BarcodeNumber", response)) > 0
+        else None
+    )
 
     return details, errors
 
@@ -83,7 +87,7 @@ def shipment_request(
         FromMiddleInitial=None,
         FromLastName=shipper.person_name,
         FromFirm=shipper.company_name or "N/A",
-        FromAddress1=shipper.address_line2,
+        FromAddress1=shipper.address_line2 or "",
         FromAddress2=shipper.street,
         FromUrbanization=None,
         FromCity=shipper.city,
@@ -96,7 +100,7 @@ def shipment_request(
         ToFirstName=recipient.person_name,
         ToLastName=None,
         ToFirm=recipient.company_name or "N/A",
-        ToAddress1=recipient.address_line2,
+        ToAddress1=recipient.address_line2 or "",
         ToAddress2=recipient.street,
         ToAddress3=None,
         ToCity=recipient.city,

--- a/modules/connectors/usps_international/setup.py
+++ b/modules/connectors/usps_international/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="karrio.usps_international",
-    version="2023.9.2",
+    version="2023.9.13",
     description="Karrio - USPS International Shipping extension",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/modules/connectors/usps_international/tests/usps_international/test_shipment/test_first_class.py
+++ b/modules/connectors/usps_international/tests/usps_international/test_shipment/test_first_class.py
@@ -134,6 +134,7 @@ ShipmentRequestXML = """<eVSFirstClassMailIntlRequest USERID="username">
     <ToFirstName>John</ToFirstName>
     <ToLastName>John</ToLastName>
     <ToFirm>Coffee Five</ToFirm>
+    <ToAddress1></ToAddress1>
     <ToAddress2>01 R. da Quitanda, 86 - quiosque</ToAddress2>
     <ToCity>Centro</ToCity>
     <ToProvince>Rio de Janeiro</ToProvince>

--- a/modules/connectors/usps_international/tests/usps_international/test_shipment/test_global_express_guaranteed.py
+++ b/modules/connectors/usps_international/tests/usps_international/test_shipment/test_global_express_guaranteed.py
@@ -121,6 +121,7 @@ ShipmentRequestXML = """<eVSGXGGetLabelRequest USERID="username" PASSWORD="passw
     <ToLastName>John</ToLastName>
     <ToFirm>Coffee Five</ToFirm>
     <ToAddress1>01 R. da Quitanda, 86 - quiosque</ToAddress1>
+    <ToAddress2></ToAddress2>
     <ToPostalCode>29440</ToPostalCode>
     <ToPhone>8005554526</ToPhone>
     <ToDPID>000</ToDPID>

--- a/modules/connectors/usps_international/tests/usps_international/test_shipment/test_priority_express.py
+++ b/modules/connectors/usps_international/tests/usps_international/test_shipment/test_priority_express.py
@@ -137,6 +137,7 @@ ShipmentRequestXML = """<eVSExpressMailIntlRequest USERID="username" PASSWORD="p
     <ToFirstName>John</ToFirstName>
     <ToLastName>John</ToLastName>
     <ToFirm>Coffee Five</ToFirm>
+    <ToAddress1></ToAddress1>
     <ToAddress2>R. da Quitanda, 86 - quiosque 01</ToAddress2>
     <ToCity>Centro</ToCity>
     <ToProvince>Rio de Janeiro</ToProvince>

--- a/modules/connectors/usps_international/tests/usps_international/test_shipment/test_priority_mail.py
+++ b/modules/connectors/usps_international/tests/usps_international/test_shipment/test_priority_mail.py
@@ -181,6 +181,7 @@ ShipmentRequestXML = """<eVSPriorityMailIntlRequest USERID="username">
     <FromPhone>1234567890</FromPhone>
     <ToFirstName>John</ToFirstName>
     <ToFirm>Coffee Five</ToFirm>
+    <ToAddress1></ToAddress1>
     <ToAddress2>01 R. da Quitanda, 86 - quiosque</ToAddress2>
     <ToCity>Centro</ToCity>
     <ToProvince>Rio de Janeiro</ToProvince>


### PR DESCRIPTION
- fix(#491): USPS label response conditional parsing when errors are returned and set defaults for secondary address lines