### PR TITLE
Disable "note" alert types as previously done in fedex_ws

### DIFF
--- a/modules/connectors/fedex/karrio/providers/fedex/error.py
+++ b/modules/connectors/fedex/karrio/providers/fedex/error.py
@@ -24,6 +24,7 @@ def parse_error_response(
                     [{"message": result["output"]["message"]}]
                     if "message" in result.get("output", {})
                     and isinstance(result["output"]["message"], str)
+                    and not result["output"]["alertType"] != "NOTE"
                     else []
                 ),
                 *(


### PR DESCRIPTION
We have previously chosen to disregard "note" alerts from fedex in fedex_ws due to their extensive number. As such, they will be ignored for the time being.

**Reference to our approach in fedex_ws:** https://github.com/karrioapi/karrio/blob/4d2a07b6c3c1a267783e0275260f523882b149ef/modules/connectors/fedex_ws/karrio/providers/fedex_ws/error.py#L20-L20

The handling of note messages as a distinct error type can be revised and better integrated into our codebase in future updates


