### PR TITLE
Fix eShipper server URL for production mode and label problem

### DIFF
--- a/modules/connectors/eshipper/karrio/providers/eshipper/shipment/create.py
+++ b/modules/connectors/eshipper/karrio/providers/eshipper/shipment/create.py
@@ -27,7 +27,7 @@ def _extract_details(
     settings: provider_utils.Settings,
 ) -> models.ShipmentDetails:
     shipment = lib.to_object(shipping.ShippingResponseType, data)
-    label_type = next((_.type for _ in shipment.labelData.label), "PDF")
+    label_type = next((_.type for _ in shipment.labelData.label), "PDF").upper()
     label = lib.bundle_base64([_.data for _ in shipment.labelData.label], label_type)
     trackingNumbers = [_.trackingNumber for _ in shipment.packages]
 

--- a/modules/connectors/eshipper/karrio/providers/eshipper/utils.py
+++ b/modules/connectors/eshipper/karrio/providers/eshipper/utils.py
@@ -16,7 +16,7 @@ class Settings(core.Settings):
 
     @property
     def server_url(self):
-        return "https://uu2.eshipper.com"
+        return "https://uu2.eshipper.com" if self.test_mode else "https://ww2.eshipper.com"
 
     @property
     def access_token(self):


### PR DESCRIPTION
The URL property has been updated to return the correct URL based on the flag. This ensures that the production and test environments are targeted correctly.

Eshipper returns the label type as lowercase, but the system uses uppercase. Therefore, a conversion has been added.