### PR TITLE
Fix FedEx multi shipment creating multiple of packages

### DIFF
--- a/modules/connectors/fedex/karrio/providers/fedex/shipment/create.py
+++ b/modules/connectors/fedex/karrio/providers/fedex/shipment/create.py
@@ -647,7 +647,7 @@ def shipment_request(
                         )
                         else None
                     ),
-                    groupPackageCount=package_index,
+                    groupPackageCount=1,
                     itemDescriptionForClearance=None,
                     contentRecord=[],
                     itemDescription=package.parcel.description,
@@ -673,7 +673,7 @@ def shipment_request(
                     ),
                     trackingNumber=None,
                 )
-                for package_index, package in enumerate(packages, start=1)
+                for package in packages
             ],
         ),
         labelResponseOptions="LABEL",


### PR DESCRIPTION
A bug was creating multiple of the same package if packages were more then 1

in the future we can have a function that conslidate same dimantine packages to only show one time in the api and ask for x times the same pacakge