### PR TITLE
Fix: set shipping date to now if it is in the past

### DIFF
--- a/modules/connectors/eshipper/karrio/providers/eshipper/rate.py
+++ b/modules/connectors/eshipper/karrio/providers/eshipper/rate.py
@@ -79,6 +79,9 @@ def rate_request(
     )
     shipping_date = lib.to_date(options.shipment_date.state or datetime.datetime.now())
 
+    if shipping_date < datetime.datetime.now():
+        shipping_date = datetime.datetime.now()
+
     request = eshipper.RateRequestType(
         scheduledShipDate=lib.fdatetime(shipping_date, output_format="%Y-%m-%d %H:%M"),
         raterequestfrom=eshipper.FromType(

--- a/modules/connectors/eshipper/karrio/providers/eshipper/shipment/create.py
+++ b/modules/connectors/eshipper/karrio/providers/eshipper/shipment/create.py
@@ -111,6 +111,9 @@ def shipment_request(
     )
     shipping_date = lib.to_date(options.shipment_date.state or datetime.datetime.now())
 
+    if shipping_date < datetime.datetime.now():
+        shipping_date = datetime.datetime.now()
+
     request = eshipper.ShippingRequestType(
         scheduledShipDate=lib.fdatetime(shipping_date, output_format="%Y-%m-%d %H:%M"),
         shippingrequestfrom=eshipper.FromType(


### PR DESCRIPTION
Ensures that shipping date isn't set to a past date, correcting to the current date if necessary. Eshipper Skip Carrier was complaining that date is before now, because they don't like when its pest time