### PR TITLE
fix: service name and carrier name parsing

### DIFF
--- a/modules/connectors/eshipper/karrio/providers/eshipper/rate.py
+++ b/modules/connectors/eshipper/karrio/providers/eshipper/rate.py
@@ -29,7 +29,7 @@ def _extract_details(
     service = provider_units.ShippingService.map(str(rate.serviceId))
     carrierId = provider_units.ShippingService.carrier_id(service.value_or_key)
     rate_provider = provider_units.ShippingService.carrier(service.value_or_key).lower()
-    service_name = service.name.replace("eshipper_", "")
+    service_name = (service.name or rate.serviceName.lower().replace(" ", "_")).replace("eshipper_", "")
 
     charges = [
         ("baseCharge", rate.baseCharge),

--- a/modules/connectors/eshipper/karrio/providers/eshipper/rate.py
+++ b/modules/connectors/eshipper/karrio/providers/eshipper/rate.py
@@ -29,6 +29,8 @@ def _extract_details(
     service = provider_units.ShippingService.map(str(rate.serviceId))
     carrierId = provider_units.ShippingService.carrier_id(service.value_or_key)
     rate_provider = provider_units.ShippingService.carrier(service.value_or_key).lower()
+    service_name = service.name.replace("eshipper_", "")
+
     charges = [
         ("baseCharge", rate.baseCharge),
         ("fuelSurcharge", rate.fuelSurcharge),
@@ -56,8 +58,9 @@ def _extract_details(
             if amount
         ],
         meta=dict(
+            carrier=rate_provider,
             rate_provider=rate_provider,
-            service_name=rate.serviceName or service.name,
+            service_name=service_name,
             carrierId=carrierId,
             serviceName=rate.serviceName,
             carrierName=rate.carrierName,


### PR DESCRIPTION
this fixes the bug that currently eshipper returns itself as the carrier, and it's different from how it was in the eshipper lagecy XML API, and how other providers that provide multi carrier rates. 

```json
      "meta": {
        "carrier": "eshipper",
        "carrierId": "5000011",
        "carrierName": "Purolator",
        "carrier_connection_id": "car_4b3f387ad1fc4daca568756d12475346",
        "ext": "eshipper",
        "rate_provider": "eshipper",
        "serviceName": "Purolator Ground",
        "service_name": "PUROLATOR GROUND"
      },
```

