### PR TITLE
Proposal to add health check due to api startup that somehow can be slow

### DIFF
--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -6,6 +6,7 @@ ARG REGISTRY_TOKEN
 ARG REGISTRY_TOKEN_NAME
 
 RUN apt-get update -y && apt-get install -y gcc
+
 RUN python -m venv /karrio/venv
 ENV PATH="/karrio/venv/bin:$PATH"
 COPY "${REQUIREMENTS}" /temp/
@@ -42,7 +43,7 @@ ENV LOG_DIR /karrio/log
 ENV WORKER_DB_DIR /karrio/data
 ENV STATIC_ROOT_DIR /karrio/static
 
-RUN apt-get update -y && apt-get install -y libpango1.0-0 libpangoft2-1.0-0 gcc ghostscript
+RUN apt-get update -y && apt-get install -y libpango1.0-0 libpangoft2-1.0-0 gcc ghostscript curl
 RUN useradd -m karrio -d /karrio
 USER karrio
 COPY --chown=karrio:karrio --from=compile-image /karrio/ /karrio/

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -50,7 +50,7 @@ services:
 
   dashboard:
     container_name: karrio.dashboard
-    image: karrio.docker.scarf.sh/karrio/dashboard:2024.6.3
+    image: karrio.docker.scarf.sh/karrio/dashboard:2024.6.4
     restart: unless-stopped
     ports:
       - ${DASHBOARD_PORT}:3000/tcp

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -30,7 +30,7 @@ services:
 
   worker:
     container_name: karrio.worker
-    image: karrio-api:local
+    image: karrio.docker.scarf.sh/karrio/server:2024.6.4
     restart: unless-stopped
     depends_on:
       - db

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   api:
     container_name: karrio.api
-    image: karrio-api:local
+    image: karrio.docker.scarf.sh/karrio/server:2024.6.4
     restart: unless-stopped
     ports:
       - ${KARRIO_HTTP_PORT}:${KARRIO_HTTP_PORT}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,13 +1,19 @@
 services:
   api:
     container_name: karrio.api
-    image: karrio.docker.scarf.sh/karrio/server:2024.6.4
+    image: karrio-api:local
     restart: unless-stopped
     ports:
       - ${KARRIO_HTTP_PORT}:${KARRIO_HTTP_PORT}
     depends_on:
       - db
       - redis
+    healthcheck:
+      test: curl --fail http://api:5002/ || exit 1
+      interval: 40s
+      timeout: 30s
+      retries: 5
+      start_period: 60s
     environment:
       DEBUG_MODE: "True"
       DETACHED_WORKER: "True"
@@ -24,7 +30,7 @@ services:
 
   worker:
     container_name: karrio.worker
-    image: karrio.docker.scarf.sh/karrio/server:2024.6.4
+    image: karrio-api:local
     restart: unless-stopped
     depends_on:
       - db
@@ -44,12 +50,14 @@ services:
 
   dashboard:
     container_name: karrio.dashboard
-    image: karrio.docker.scarf.sh/karrio/dashboard:2024.6.4
+    image: karrio.docker.scarf.sh/karrio/dashboard:2024.6.3
     restart: unless-stopped
     ports:
       - ${DASHBOARD_PORT}:3000/tcp
     depends_on:
-      - api
+      api:
+        condition: service_healthy
+        restart: true
     environment:
       KARRIO_URL: http://api:${KARRIO_HTTP_PORT:-5002}
       NEXTAUTH_SECRET: ${JWT_SECRET}


### PR DESCRIPTION
Hi guys, 

Thank you so much for the hardwork, it's great apps and smooth apps. I also build something like this but for my private client and using several local shipment  service in indonesia.

Just my two cents,  when i started to test karrio i realize that API container startups is sometimes really slow. So i came up with this idea to add healthcheck in docker compose so users will understand why their frontend returning such error because the API not finished startup yet.

But let me know if such discussion already made or maybe any specific concern arose before that end up to not add this kind of functionality to docker compose due that concern

Thank you!

Best regards,
Panji