### PR TITLE
Fedex tracker updates and dashboard Tracker updates

### DIFF
--- a/modules/connectors/fedex/karrio/mappers/fedex/proxy.py
+++ b/modules/connectors/fedex/karrio/mappers/fedex/proxy.py
@@ -9,7 +9,6 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-
 class Proxy(proxy.Proxy):
     settings: provider_settings.Settings
 

--- a/modules/connectors/fedex/karrio/mappers/fedex/proxy.py
+++ b/modules/connectors/fedex/karrio/mappers/fedex/proxy.py
@@ -1,8 +1,13 @@
+import typing
 import urllib.parse
 import karrio.lib as lib
 import karrio.api.proxy as proxy
 import karrio.providers.fedex.utils as provider_utils
 import karrio.mappers.fedex.settings as provider_settings
+import karrio.schemas.fedex.tracking_document_request as fedex
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class Proxy(proxy.Proxy):
@@ -26,6 +31,7 @@ class Proxy(proxy.Proxy):
         return lib.Deserializable(response, lib.to_dict, request.ctx)
 
     def get_tracking(self, request: lib.Serializable) -> lib.Deserializable:
+        logger.debug(f"get_tracking settings: {self.settings}")
         response = lib.request(
             url=f"{self.settings.server_url}/track/v1/trackingnumbers",
             data=lib.to_json(request.serialize()),
@@ -142,3 +148,80 @@ class Proxy(proxy.Proxy):
         )
 
         return lib.Deserializable(response, lib.to_dict, request.ctx)
+    
+    def get_proof_of_delivery(self, tracking_number: str) -> typing.Optional[str]:
+        import karrio.providers.fedex.error as error
+        logger.debug(f"Entering get_proof_of_delivery for tracking number {tracking_number}")
+        logger.debug(f"Using access token of Bearer")
+        logger.debug(self.settings)
+        logger.debug(self.settings.track_access_token)
+        logger.debug("------")
+
+        # Construct the request
+        request = fedex.TrackingDocumentRequestType(
+            trackDocumentSpecification=[
+                fedex.TrackDocumentSpecificationType(
+                    trackingNumberInfo=fedex.TrackingNumberInfoType(
+                        trackingNumber=tracking_number
+                    )
+                )
+            ],
+            trackDocumentDetail=fedex.TrackDocumentDetailType(
+                documentType="SIGNATURE_PROOF_OF_DELIVERY",
+                documentFormat="PNG",
+            ),
+        )
+        logger.debug(f"Request package: {lib.to_json(request)}")  # Log full request as JSON
+
+        try:
+            # Send the request
+            logger.debug("Sending request to fedex...")
+            response = lib.to_dict(
+                lib.request(
+                    url=f"{self.settings.server_url}/track/v1/trackingdocuments",
+                    data=lib.to_json(request),
+                    method="POST",
+                    headers={
+                        "x-locale": "en_US",
+                        "content-type": "application/json",
+                        "authorization": f"Bearer {self.settings.track_access_token}",
+                    },
+                    decoder=provider_utils.parse_response,
+                    on_error=lambda b: self.log_request_error(b),  # Custom error handler
+                )
+            )
+            logger.debug("Processing fedex response...")
+
+            logger.debug(f"Full response from POST to trackingdocuments: {response}")
+
+            # Check if there are any error messages in the response
+            logger.debug("Checking response for errors...")
+            messages = error.parse_error_response(response, self.settings)
+            if any(messages):
+                logger.error(f"FedEx SPOD Error for tracking number {tracking_number}: {messages}")
+                return None
+
+            # Check if the documents are present in the response
+            logger.debug("Parsing documents from response!")
+            documents = response.get("output", {}).get("documents")
+            if not documents:
+                logger.error(f"No POD documents found in the response for tracking number {tracking_number}")
+                return None
+
+            # Convert documents to base64
+            logger.debug(f"bundling documents")
+            #return lib.failsafe(lambda: lib.bundle_base64(documents, format="PNG"))
+            docs_to_return = lib.bundle_base64(documents, format="PNG")
+            logger.debug(f"Docs to return {docs_to_return}")
+            return docs_to_return
+        
+        except Exception as e:
+            # Catch any other exceptions and log the details
+            logger.error(f"An error occurred while fetching POD for tracking number {tracking_number}: {e}")
+            return None
+
+    def log_request_error(self, response_body):
+        # Custom handler for logging errors during the request
+        error_content = response_body.read().decode()
+        logger.error(f"FedEx API Request Error: {error_content}")
+        return provider_utils.parse_response(error_content)

--- a/modules/connectors/fedex/karrio/providers/fedex/tracking.py
+++ b/modules/connectors/fedex/karrio/providers/fedex/tracking.py
@@ -122,10 +122,16 @@ def _extract_details(
             shipment_origin_country=lib.failsafe(
                 lambda: detail.originLocation.locationContactAndAddress.address.countryCode
             ),
-            signed_by=lib.failsafe(lambda: detail.deliveryDetails.signedByName),
+            signed_by=lib.failsafe(
+                lambda: (
+                    detail.deliveryDetails.signedByName
+                    if detail.deliveryDetails.signedByName
+                    else (detail.deliveryDetails.receivedByName)
+                )
+            ),
         ),
         images=lib.identity(models.Images(signature_image=img) if img else None),
-        estimated_delivery=estimated_delivery,
+        estimated_delivery=lib.fdate(estimated_delivery, try_formats=DATETIME_FORMATS),
         delivered=(status == "delivered"),
         status=status,
     )

--- a/modules/connectors/fedex/karrio/providers/fedex/tracking.py
+++ b/modules/connectors/fedex/karrio/providers/fedex/tracking.py
@@ -131,7 +131,7 @@ def _extract_details(
             ),
         ),
         images=lib.identity(models.Images(signature_image=img) if img else None),
-        estimated_delivery=lib.fdate(estimated_delivery, try_formats=DATETIME_FORMATS),
+        estimated_delivery=estimated_delivery,
         delivered=(status == "delivered"),
         status=status,
     )

--- a/modules/connectors/fedex/karrio/providers/fedex/tracking.py
+++ b/modules/connectors/fedex/karrio/providers/fedex/tracking.py
@@ -7,10 +7,6 @@ import karrio.providers.fedex.error as provider_error
 import karrio.providers.fedex.utils as provider_utils
 import karrio.providers.fedex.units as provider_units
 import karrio.mappers.fedex.proxy as proxy
-import logging
-
-logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.DEBUG)
 
 
 DATETIME_FORMATS = ["%Y-%m-%dT%H:%M:%S%z", "%Y-%m-%dT%H:%M:%S"]
@@ -75,26 +71,19 @@ def _extract_details(
     )
     delivered = status == "delivered"
     # Create a proxy instance with settings
-    logger.debug(f"Settings being passed to the proxy_instance: {settings}")
     proxy_instance = proxy.Proxy(settings=settings)
 
-    # img = lib.failsafe(
-    #     lambda: (
-    #         proxy_instance.get_proof_of_delivery(package.trackingNumber)
-    #         if delivered
-    #         else None
-    #     )
-    # )
-    img = (
-        proxy_instance.get_proof_of_delivery(package.trackingNumber)
-        if delivered
-        else None
+    img = lib.failsafe(
+        lambda: (
+            proxy_instance.get_proof_of_delivery(package.trackingNumber)
+            if delivered
+            else None
+        )
     )
-    logger.debug(f"Image for {package.trackingNumber}: {img}")
-    if img:
-        logger.info(f"Successfully retrieved SPOD image for {package.trackingNumber}")
-    else:
-        logger.warning(f"No SPOD image available for {package.trackingNumber}")
+    # if img:
+    #     logger.info(f"Successfully retrieved SPOD image for {package.trackingNumber}")
+    # else:
+    #     logger.warning(f"No SPOD image available for {package.trackingNumber}")
 
 
     return models.TrackingDetails(

--- a/modules/connectors/fedex/karrio/providers/fedex/utils.py
+++ b/modules/connectors/fedex/karrio/providers/fedex/utils.py
@@ -1,11 +1,12 @@
-import karrio.schemas.fedex.tracking_document_request as fedex
 import gzip
 import datetime
 import urllib.parse
 import karrio.lib as lib
 import karrio.core as core
 import karrio.core.errors as errors
+import logging
 
+logger = logging.getLogger(__name__)
 
 class Settings(core.Settings):
     """FedEx connection settings."""
@@ -140,42 +141,6 @@ def login(settings: Settings, client_id: str = None, client_secret: str = None):
     )
 
     return {**response, "expiry": lib.fdatetime(expiry)}
-
-
-def get_proof_of_delivery(tracking_number: str, settings: Settings):
-    import karrio.providers.fedex.error as error
-
-    request = fedex.TrackingDocumentRequestType(
-        trackDocumentSpecification=[
-            fedex.TrackDocumentSpecificationType(
-                trackingNumberInfo=fedex.TrackingNumberInfoType(
-                    trackingNumber=tracking_number
-                )
-            )
-        ],
-        trackDocumentDetail=fedex.TrackDocumentDetailType(
-            documentType="SIGNATURE_PROOF_OF_DELIVERY",
-            documentFormat="PNG",
-        ),
-    )
-    response = lib.to_dict(
-        lib.request(
-            url=f"{settings.server_url}/track/v1/trackingdocuments",
-            data=lib.to_json(request),
-            method="POST",
-            decoder=parse_response,
-            on_error=lambda b: parse_response(b.read()),
-        )
-    )
-
-    messages = error.parse_error_response(response, settings)
-
-    if any(messages):
-        return None
-
-    return lib.failsafe(
-        lambda: lib.bundle_base64(response["output"]["documents"], format="PNG")
-    )
 
 
 def parse_response(binary_string):

--- a/modules/connectors/fedex/tests/fedex/test_tracking.py
+++ b/modules/connectors/fedex/tests/fedex/test_tracking.py
@@ -107,7 +107,7 @@ ParsedTrackingResponse = [
                 "shipment_origin_postal_code": "98101",
                 "shipment_origin_country": "US",
                 "shipment_service": "FedEx Freight Economy.",
-                "signed_by": "Reciever",
+                "signed_by": "Reciever", # How do I do a test for the 'fall over' when we set signed_by to recievedBy instead of signedBy?
             },
             "status": "in_transit",
             "tracking_number": "123456789012",

--- a/packages/core/components/TrackingEvents.tsx
+++ b/packages/core/components/TrackingEvents.tsx
@@ -1,0 +1,47 @@
+// components/TrackingEvents.tsx
+import { TrackingEvent, TrackingStatus } from "@karrio/types/rest/api";
+import { formatDayDate } from "@karrio/lib";
+
+type DayEvents = { [k: string]: TrackingEvent[] };
+
+const computeEvents = (tracker: TrackingStatus): DayEvents => {
+  return (tracker?.events || []).reduce((days, event: TrackingEvent) => {
+    const daydate = formatDayDate(event.date as string);
+    return { ...days, [daydate]: [...(days[daydate] || []), event] };
+  }, {} as DayEvents);
+};
+
+const TrackingEvents: React.FC<{ tracker: TrackingStatus }> = ({ tracker }) => {
+  const eventsByDay = computeEvents(tracker);
+
+  return (
+    <div className="my-6">
+      <aside className="menu">
+        <ul className="menu-list mb-5" style={{ maxWidth: "28rem" }}>
+          {Object.entries(eventsByDay).map(([day, events], index) => (
+            <li key={index}>
+              <p className="menu-label is-size-6 is-capitalized">{day}</p>
+              {events.map((event, index) => (
+                <ul key={index}>
+                  <li className="my-2">
+                    <code>{event.time}</code>
+                    <span className="is-subtitle is-size-7 my-1 has-text-weight-semibold">
+                      {event.location}
+                    </span>
+                  </li>
+                  <li className="my-2">
+                    <span className="is-subtitle is-size-7 my-1 has-text-weight-semibold has-text-grey">
+                      {event.description}
+                    </span>
+                  </li>
+                </ul>
+              ))}
+            </li>
+          ))}
+        </ul>
+      </aside>
+    </div>
+  );
+};
+
+export default TrackingEvents;

--- a/packages/core/components/TrackingEvents.tsx
+++ b/packages/core/components/TrackingEvents.tsx
@@ -1,18 +1,29 @@
 // components/TrackingEvents.tsx
 import { TrackingEvent, TrackingStatus } from "@karrio/types/rest/api";
 import { formatDayDate } from "@karrio/lib";
+import { TrackerType } from "@karrio/types";
 
 type DayEvents = { [k: string]: TrackingEvent[] };
 
 const computeEvents = (tracker: TrackingStatus): DayEvents => {
-  return (tracker?.events || []).reduce((days, event: TrackingEvent) => {
+  const days: DayEvents = {};
+
+  (tracker?.events || []).forEach((event: TrackingEvent) => {
     const daydate = formatDayDate(event.date as string);
-    return { ...days, [daydate]: [...(days[daydate] || []), event] };
-  }, {} as DayEvents);
+
+    if (!days[daydate]) {
+      days[daydate] = [];
+    }
+
+    days[daydate].push(event);
+  });
+
+  return days;
 };
 
-const TrackingEvents: React.FC<{ tracker: TrackingStatus }> = ({ tracker }) => {
-  const eventsByDay = computeEvents(tracker);
+
+const TrackingEvents: React.FC<{ tracker: TrackerType }> = ({ tracker }) => {
+  const eventsByDay = computeEvents(tracker as TrackingStatus);
 
   return (
     <div className="my-6">

--- a/packages/core/components/TrackingHeader.tsx
+++ b/packages/core/components/TrackingHeader.tsx
@@ -1,10 +1,9 @@
 // components/TrackingHeader.tsx
-import { TrackingStatus } from "@karrio/types/rest/api";
 import { TrackerStatusEnum, TrackerType } from "@karrio/types";
 import { formatDayDate, formatRef, isNone } from "@karrio/lib";
 import { CarrierImage } from "@karrio/ui/components/carrier-image";
 
-const TrackingHeader: React.FC<{ tracker: TrackingStatus }> = ({ tracker }) => {
+const TrackingHeader: React.FC<{ tracker: TrackerType }> = ({ tracker }) => {
   const computeColor = (tracker: TrackerType) => {
     if (tracker?.delivered) return "has-background-success";
     else if (tracker?.status === TrackerStatusEnum.pending.toString())
@@ -77,7 +76,7 @@ const TrackingHeader: React.FC<{ tracker: TrackingStatus }> = ({ tracker }) => {
             Additional Information
           </p>
           <div className="columns is-multiline">
-            {Object.entries(tracker.info)
+            {Object.entries(tracker.info || {})
               .filter(([_, value]) => value != null) // Exclude null or undefined values
               .map(([key, value], index) => (
                 <div key={index} className="column is-6">

--- a/packages/core/components/TrackingHeader.tsx
+++ b/packages/core/components/TrackingHeader.tsx
@@ -1,0 +1,103 @@
+// components/TrackingHeader.tsx
+import { TrackingStatus } from "@karrio/types/rest/api";
+import { TrackerStatusEnum, TrackerType } from "@karrio/types";
+import { formatDayDate, formatRef, isNone } from "@karrio/lib";
+import { CarrierImage } from "@karrio/ui/components/carrier-image";
+
+const TrackingHeader: React.FC<{ tracker: TrackingStatus }> = ({ tracker }) => {
+  const computeColor = (tracker: TrackerType) => {
+    if (tracker?.delivered) return "has-background-success";
+    else if (tracker?.status === TrackerStatusEnum.pending.toString())
+      return "has-background-grey-dark";
+    else if (
+      [
+        TrackerStatusEnum.on_hold.toString(),
+        TrackerStatusEnum.delivery_delayed.toString(),
+      ].includes(tracker?.status as string)
+    )
+      return "has-background-warning";
+    else if (
+      [TrackerStatusEnum.unknown.toString()].includes(
+        tracker?.status as string,
+      )
+    )
+      return "has-background-grey";
+    else if (
+      [TrackerStatusEnum.delivery_failed.toString()].includes(
+        tracker?.status as string,
+      )
+    )
+      return "has-background-danger";
+    else return "has-background-info";
+  };
+  const computeStatus = (tracker: TrackerType) => {
+    if (tracker?.delivered) return "Delivered";
+    else if (tracker?.status === TrackerStatusEnum.pending.toString())
+      return "Pending";
+    else if (
+      [
+        TrackerStatusEnum.on_hold.toString(),
+        TrackerStatusEnum.delivery_delayed.toString(),
+        TrackerStatusEnum.ready_for_pickup.toString(),
+        TrackerStatusEnum.unknown.toString(),
+        TrackerStatusEnum.delivery_failed.toString(),
+      ].includes(tracker?.status as string)
+    )
+      return formatRef(tracker!.status as string);
+    else return "In-Transit";
+  };
+
+  return (
+    <>
+      <div className="pb-4 is-flex is-justify-content-center">
+        <CarrierImage
+          carrier_name={tracker.carrier_name}
+          width={60}
+          height={60}
+        />
+      </div>
+
+      <p className="subtitle has-text-centered is-6 my-3">
+        <span>Tracking ID</span> <strong>{tracker.tracking_number}</strong>
+      </p>
+
+      {!isNone(tracker?.estimated_delivery) && (
+        <p className="subtitle has-text-centered is-6 mb-3">
+          <span>{tracker?.delivered ? "Delivered" : "Estimated Delivery"}</span>{" "}
+          <strong>
+            {formatDayDate(tracker!.estimated_delivery as string)}
+          </strong>
+        </p>
+      )}
+
+      {!isNone(tracker?.info) && (
+        <>
+          <hr />
+          <p className="has-text-weight-bold my-4 is-size-6">
+            Additional Information
+          </p>
+          <div className="columns is-multiline">
+            {Object.entries(tracker.info)
+              .filter(([_, value]) => value != null) // Exclude null or undefined values
+              .map(([key, value], index) => (
+                <div key={index} className="column is-6">
+                  <strong>{key}: </strong> <span>{String(value)}</span>
+                </div>
+              ))}
+          </div>
+        </>
+      )}
+
+      <p
+        className={
+          computeColor(tracker as TrackerType) +
+          " block has-text-centered has-text-white is-size-4 py-3"
+        }
+      >
+        {computeStatus(tracker as TrackerType)}
+      </p>
+    </>
+  );
+};
+
+export default TrackingHeader;

--- a/packages/core/components/TrackingMessages.tsx
+++ b/packages/core/components/TrackingMessages.tsx
@@ -1,9 +1,8 @@
-// components/TrackingMessages.tsx
 import React from "react";
 import { TrackerType } from "@karrio/types";
 
 interface TrackingMessagesProps {
-  messages: TrackerType["messages"];
+  messages: (TrackerType["messages"] extends (infer U)[] ? U : never)[]; // Allow flexibility for undefined/null
 }
 
 const TrackingMessages: React.FC<TrackingMessagesProps> = ({ messages }) => {
@@ -11,9 +10,15 @@ const TrackingMessages: React.FC<TrackingMessagesProps> = ({ messages }) => {
 
   return (
     <div className="notification is-warning">
-      <p className="is-size-7 my-1 has-text-weight-semibold has-text-grey">
-        {messages[0]?.message}
-      </p>
+      {messages.map((msg, index) => (
+        <p
+          key={index}
+          className="is-size-7 my-1 has-text-weight-semibold has-text-grey"
+        >
+          {msg?.message ?? "No message available"}{" "}
+          {/* Handle undefined/null message */}
+        </p>
+      ))}
     </div>
   );
 };

--- a/packages/core/components/TrackingMessages.tsx
+++ b/packages/core/components/TrackingMessages.tsx
@@ -1,0 +1,21 @@
+// components/TrackingMessages.tsx
+import React from "react";
+import { TrackerType } from "@karrio/types";
+
+interface TrackingMessagesProps {
+  messages: TrackerType["messages"];
+}
+
+const TrackingMessages: React.FC<TrackingMessagesProps> = ({ messages }) => {
+  if (!messages || messages.length === 0) return null;
+
+  return (
+    <div className="notification is-warning">
+      <p className="is-size-7 my-1 has-text-weight-semibold has-text-grey">
+        {messages[0]?.message}
+      </p>
+    </div>
+  );
+};
+
+export default TrackingMessages;

--- a/packages/core/components/tracking-preview.tsx
+++ b/packages/core/components/tracking-preview.tsx
@@ -139,6 +139,24 @@ export const TrackingPreview: React.FC<TrackingPreviewComponent> = ({
                 <strong>{tracker?.tracking_number}</strong>
               </p>
 
+              {!isNone(tracker?.info) && (
+                <>
+                  <hr />
+                  <p className="has-text-weight-bold my-4 is-size-6">
+                    Additional Information
+                  </p>
+                  <div className="columns is-multiline">
+                    {Object.entries(tracker?.info || {})
+                      .filter(([_, value]) => value != null) // Exclude null or undefined values
+                      .map(([key, value], index) => (
+                        <div key={index} className="column is-6">
+                          <strong>{key}: </strong> <span>{String(value)}</span>
+                        </div>
+                      ))}
+                  </div>
+                </>
+              )}
+
               {!isNone(tracker?.estimated_delivery) && (
                 <p className="subtitle has-text-centered is-6 mb-3">
                   <span>

--- a/packages/core/components/tracking-preview.tsx
+++ b/packages/core/components/tracking-preview.tsx
@@ -72,7 +72,7 @@ export const TrackingPreview: React.FC<TrackingPreviewComponent> = ({
         {!isNone(tracker) && (
           <div className="modal-card">
             <section className="modal-card-body">
-              <TrackingHeader tracker={tracker as TrackingType} />
+              <TrackingHeader tracker={tracker as TrackerType} />
 
               <hr />
 
@@ -80,7 +80,7 @@ export const TrackingPreview: React.FC<TrackingPreviewComponent> = ({
                 className="my-3 pl-3"
                 style={{ maxHeight: "40vh", overflowY: "scroll" }}
               >
-                <TrackingEvents tracker={tracker as TrackingType} />
+                <TrackingEvents tracker={tracker as TrackerType} />
               </div>
 
               <TrackingMessages messages={tracker?.messages || [] } />

--- a/packages/core/modules/Trackers/index.tsx
+++ b/packages/core/modules/Trackers/index.tsx
@@ -281,7 +281,7 @@ export default function TrackersPage(pageProps: any) {
                           onClick={(e) => {
                             e.stopPropagation();
                             confirmDeletion({
-                              label: "Delet Shipment Tracker",
+                              label: "Delete Shipment Tracker",
                               identifier: tracker.id as string,
                               onConfirm: remove(tracker.id),
                             });

--- a/packages/core/modules/Trackers/index.tsx
+++ b/packages/core/modules/Trackers/index.tsx
@@ -24,7 +24,7 @@ import { dynamicMetadata } from "@karrio/core/components/metadata";
 import { StatusBadge } from "@karrio/ui/components/status-badge";
 import { useLoader } from "@karrio/ui/components/loader";
 import { Spinner } from "@karrio/ui/components/spinner";
-import { TrackingEvent } from "@karrio/types/rest/api";
+import { TrackingEvent, TrackingInfo } from "@karrio/types/rest/api";
 import React, { useContext, useEffect } from "react";
 import { useSearchParams } from "next/navigation";
 
@@ -249,22 +249,25 @@ export default function TrackersPage(pageProps: any) {
                         />
                       </td>
                       <td className="last-event is-vcentered py-1 last-event is-size-7 has-text-weight-bold has-text-grey text-ellipsis">
-                        <span
-                          className="text-ellipsis"
-                          title={
-                            isNoneOrEmpty(tracker?.events)
-                              ? ""
-                              : formatEventDescription(
-                                  (tracker?.events as TrackingEvent[])[0],
-                                )
-                          }
-                        >
-                          {isNoneOrEmpty(tracker?.events)
+                        {(() => {
+                          const formattedDescription = isNoneOrEmpty(
+                            tracker?.events,
+                          )
                             ? ""
                             : formatEventDescription(
                                 (tracker?.events as TrackingEvent[])[0],
-                              )}
-                        </span>
+                                tracker?.info as TrackingInfo,
+                              );
+
+                          return (
+                            <span
+                              className="text-ellipsis"
+                              title={formattedDescription}
+                            >
+                              {formattedDescription}
+                            </span>
+                          );
+                        })()}
                       </td>
                       <td className="date is-vcentered has-text-right">
                         <p className="is-size-7 has-text-weight-semibold has-text-grey">
@@ -351,8 +354,22 @@ export default function TrackersPage(pageProps: any) {
   );
 }
 
-function formatEventDescription(last_event?: TrackingEvent): string {
-  return last_event?.description || "";
+function formatEventDescription(
+  last_event?: TrackingEvent,
+  tracking_info?: TrackingInfo,
+): string {
+  if (!last_event) {
+    return "";
+  }
+
+  const { description } = last_event;
+  const { signed_by } = tracking_info || {};
+
+  if (description === "Delivered" && signed_by) {
+    return `${description} (Signed by: ${signed_by})`;
+  }
+
+  return description || "";
 }
 
 function formatEventDate(last_event?: TrackingEvent): string {

--- a/packages/core/modules/Trackers/tracking-page.tsx
+++ b/packages/core/modules/Trackers/tracking-page.tsx
@@ -1,11 +1,13 @@
 import { TrackingEvent, TrackingStatus } from "@karrio/types/rest/api";
 import { formatDayDate, isNone, KARRIO_API, url$ } from "@karrio/lib";
 import { dynamicMetadata } from "@karrio/core/components/metadata";
-import { CarrierImage } from "@karrio/ui/components/carrier-image";
 import { Collection, KarrioClient } from "@karrio/types";
 import { loadMetadata } from "@karrio/core/context/main";
 import Link from "next/link";
 import React from "react";
+import TrackingHeader from "@karrio/core/components/TrackingHeader";
+import TrackingEvents from "@karrio/core/components/TrackingEvents";
+import TrackingMessages from "@karrio/core/components/TrackingMessages";
 
 export const generateMetadata = dynamicMetadata("Tracking");
 
@@ -51,91 +53,20 @@ export default async function Page({ params }: { params: Collection }) {
             <>
               <div className="card isolated-card">
                 <div className="card-content">
-                  <div className="pb-4 is-flex is-justify-content-center">
-                    <CarrierImage
-                      carrier_name={tracker!.carrier_name}
-                      width={60}
-                      height={60}
-                    />
-                  </div>
-
-                  <p className="subtitle has-text-centered is-6 my-3">
-                    <span>Tracking ID</span>{" "}
-                    <strong>{tracker?.tracking_number}</strong>
-                  </p>
-
-                  {!isNone(tracker?.estimated_delivery) && (
-                    <p className="subtitle has-text-centered is-6 mb-3">
-                      <span>
-                        {tracker?.delivered
-                          ? "Delivered"
-                          : "Estimated Delivery"}
-                      </span>{" "}
-                      <strong>
-                        {formatDayDate(tracker!.estimated_delivery as string)}
-                      </strong>
-                    </p>
-                  )}
+                  <TrackingHeader tracker={tracker as TrackingType} />
                 </div>
 
-                <footer className="card-footer">
-                  {tracker?.status === "delivered" && (
-                    <p className="card-footer-item has-background-success has-text-white is-size-4">
-                      Delivered
-                    </p>
-                  )}
-
-                  {tracker?.status === "in_transit" && (
-                    <p className="card-footer-item has-background-info has-text-white is-size-4">
-                      In-Transit
-                    </p>
-                  )}
-
-                  {tracker?.status !== "delivered" &&
-                    tracker?.status !== "in_transit" && (
-                      <p className="card-footer-item has-background-grey-dark has-text-white is-size-4">
-                        Pending
-                      </p>
-                    )}
-                </footer>
+                <footer className="card-footer"></footer>
               </div>
 
               <hr />
-
-              <div className="my-6">
-                <aside className="menu">
-                  <ul className="menu-list mb-5" style={{ maxWidth: "28rem" }}>
-                    {Object.entries(
-                      computeEvents(tracker as TrackingStatus),
-                    ).map(([day, events], index) => (
-                      <li key={index}>
-                        <p className="menu-label is-size-6 is-capitalized">
-                          {day}
-                        </p>
-
-                        {events.map((event, index) => (
-                          <ul key={index}>
-                            <li className="my-2">
-                              <code>{event.time}</code>
-                              <span className="is-subtitle is-size-7 my-1 has-text-weight-semibold">
-                                {event.location}
-                              </span>
-                            </li>
-                            <li className="my-2">
-                              <span className="is-subtitle is-size-7 my-1 has-text-weight-semibold has-text-grey">
-                                {event.description}
-                              </span>
-                            </li>
-                          </ul>
-                        ))}
-                      </li>
-                    ))}
-                  </ul>
-                </aside>
-              </div>
+              
+              <TrackingEvents tracker={tracker as TrackingType} />
             </>
           )}
 
+          <TrackingMessages messages={tracker?.messages || [] } />
+          
           {!isNone(message) && (
             <div className="card isolated-card my-6">
               <div className="card-content has-text-centered ">

--- a/packages/types/rest/api.ts
+++ b/packages/types/rest/api.ts
@@ -8750,13 +8750,13 @@ export interface TrackingStatus {
      */
     'messages'?: Array<Message>;
     /**
-     * The shipment invoice URL
+     * The photo proof of delivery image URL
      * @type {string}
      * @memberof TrackingStatus
      */
     'delivery_image_url'?: string | null;
     /**
-     * The shipment invoice URL
+     * The the signature proof of delivery image URL
      * @type {string}
      * @memberof TrackingStatus
      */

--- a/packages/ui/modals/confirm-modal.tsx
+++ b/packages/ui/modals/confirm-modal.tsx
@@ -40,6 +40,7 @@ export const ConfirmModal: React.FC<ConfirmModalComponent> = ({ children }) => {
     try {
       await operation?.onConfirm();
       notify({
+        // TODO check grammar here
         type: NotificationType.success, message: `${operation?.label} successfully!...`
       });
       setTimeout(() => { close(); }, 2000);


### PR DESCRIPTION
- Fedex 'signed_by' now 'falls back' to 'receivedByName' if 'signedByName' is missing
- Tracker dashboard will display the signed_by if the status is Delivered
- Refactor the 'Tracking-preview' and 'Tracking-page' to be more DRY and reuse components (worried about my 'typescript' skills here) and add the 'additional info' to the header (might want to 'hide' this by default and give some ui "+" to show it maybe?)
- Fedex's SPOD - Signature Proof of Delivery has been refactored from the 'util' to the 'proxy' and correctly authenticates now, so that the PNG is now stored on the 'tracking-status' table (but still need help figuring out how to display/access it via the dashboard)