### PR TITLE
switch export line item description to description (dhl express)

### DIFF
--- a/modules/connectors/dhl_express/karrio/providers/dhl_express/shipment.py
+++ b/modules/connectors/dhl_express/karrio/providers/dhl_express/shipment.py
@@ -254,7 +254,7 @@ def shipment_request(
                         Quantity=item.quantity,
                         QuantityUnit="PCS",
                         Description=lib.text(
-                            item.title or item.description or "N/A", max=35
+                            item.description or item.title or "N/A", max=75
                         ),
                         Value=item.value_amount or 0.0,
                         IsDomestic=None,

--- a/modules/connectors/dhl_express/tests/dhl_express/test_shipment.py
+++ b/modules/connectors/dhl_express/tests/dhl_express/test_shipment.py
@@ -507,7 +507,7 @@ NonParelessShipmentRequestXml = """<req:ShipmentRequest xsi:schemaLocation="http
             <LineNumber>1</LineNumber>
             <Quantity>1</Quantity>
             <QuantityUnit>PCS</QuantityUnit>
-            <Description>title</Description>
+            <Description>description</Description>
             <Value>928.1</Value>
             <CommodityCode>hs_code</CommodityCode>
             <Weight>


### PR DESCRIPTION
DHL is having trouble exporting packages to the USA if we don't set the description correctly.