### PR TITLE
docs: In the cardgrid the management tile had a typo

### DIFF
--- a/apps/www/docs/index.mdx
+++ b/apps/www/docs/index.mdx
@@ -74,7 +74,7 @@ import CardGrid from "@site/src/components/CardGrid";
 
 [**Carrier Integration** Integrate and diversify your network of carriers.](/carriers/sdk/extension)
 
-[**Managment API** Manage your organizations programmatically.](/reference/management)
+[**Management API** Manage your organizations programmatically.](/reference/management)
 
 [**Self-Hosting** Learn how to deploy karrio on your own infrastructure.](/product/self-hosting)
 


### PR DESCRIPTION
- In the `cardgrid` the management tile had a typo. Managment -> Management