### PR TITLE
fix: resolve warnings of datetime library

### DIFF
--- a/modules/sdk/karrio/core/utils/datetime.py
+++ b/modules/sdk/karrio/core/utils/datetime.py
@@ -1,5 +1,5 @@
 import typing
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 
 class DATEFORMAT:
@@ -124,7 +124,7 @@ class DATEFORMAT:
     def ftimestamp(timestamp: typing.Union[str, int] = None):
         if timestamp is None:
             return None
-        return datetime.utcfromtimestamp(float(timestamp)).strftime("%H:%M")
+        return datetime.fromtimestamp(float(timestamp), timezone.utc).strftime("%H:%M")
 
     @staticmethod
     def is_business_hour(dt: datetime):


### PR DESCRIPTION
# PR Summary
This small PR resolves the `datetime` library warnings:
```python
DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
```
