### PR TITLE
fix: infinite re-render loop in useConnections hook

### DIFF
--- a/packages/hooks/carrier-connections.ts
+++ b/packages/hooks/carrier-connections.ts
@@ -15,12 +15,15 @@ export function useConnections() {
     system_connections,
   } = useSystemConnections();
 
+  const memoizedUserConnections = React.useMemo(() => user_connections, [JSON.stringify(user_connections)]);
+  const memoizedSystemConnections = React.useMemo(() => system_connections, [JSON.stringify(system_connections)]);
+
   React.useEffect(() => {
     if (!isUserFetched || !isSystemFetched) {
       return;
     }
 
-    const newCarrierOptions = [...user_connections, ...system_connections]
+    const newCarrierOptions = [...memoizedUserConnections, ...memoizedSystemConnections]
       .filter((_) => _.active && (_.config?.shipping_options || []).length > 0)
       .reduce(
         (acc, _) => ({
@@ -36,7 +39,7 @@ export function useConnections() {
       );
 
     setCarrierOptions(newCarrierOptions);
-  }, [isUserFetched, isSystemFetched, user_connections, system_connections]);
+  }, [isUserFetched, isSystemFetched, memoizedUserConnections, memoizedSystemConnections]);
 
   return {
     carrierOptions,


### PR DESCRIPTION
## Summary
- Fix infinite re-render loop in `useConnections` hook by memoizing connection arrays  
- Improve performance by preventing unnecessary `useEffect` re-runs  
- Maintain existing functionality while eliminating render cycles  

## Problem
The `useConnections` hook was experiencing infinite re-renders because `user_connections` and `system_connections` objects were being used directly in the `useEffect` dependency array. Since these objects receive new references on every render, the effect would run continuously.  

## Solution
- Added `React.useMemo` to create stable references for connection arrays  
- Used `JSON.stringify` for deep comparison to detect actual data changes  
- Updated `useEffect` to use memoized versions in both logic and dependencies  

## Files Changed
- `packages/hooks/carrier-connections.ts` – Added memoization to prevent infinite renders  
