### PR TITLE
Bugfix/warning overlap draft order

### DIFF
--- a/packages/core/modules/Orders/draft_order.tsx
+++ b/packages/core/modules/Orders/draft_order.tsx
@@ -211,8 +211,8 @@ export default function Page(pageProps: { params: Promise<{ id?: string }> }) {
         {!ready && <Spinner />}
 
         {ready && (
-          <div className="flex flex-col lg:flex-row gap-6 pb-6">
-            <div className="flex-1 lg:flex-[7] px-0 lg:min-h-[850px]">
+          <div className="flex flex-col lg:flex-row gap-6 pb-5">
+            <div className="flex-1 lg:flex-[7] px-0">
               {/* Line Items */}
               <div className="rounded-xl border bg-card text-card-foreground shadow px-0 py-3">
                 <header className="px-3 flex justify-between">
@@ -419,9 +419,6 @@ export default function Page(pageProps: { params: Promise<{ id?: string }> }) {
             </div>
 
             <div className="flex-1 lg:flex-[5] px-0 pb-6 relative">
-              <div
-                style={{ position: "sticky", top: "8.5%", right: 0, left: 0 }}
-              >
                 {/* Summary section */}
                 {!isNone(order.line_items) && (
                   <div className="rounded-xl border bg-card text-card-foreground shadow px-0 py-3 mb-5">
@@ -628,7 +625,6 @@ export default function Page(pageProps: { params: Promise<{ id?: string }> }) {
                     />
                   </div>
                 </div>
-              </div>
             </div>
           </div>
         )}

--- a/packages/core/modules/Orders/draft_order.tsx
+++ b/packages/core/modules/Orders/draft_order.tsx
@@ -187,9 +187,9 @@ export default function Page(pageProps: { params: Promise<{ id?: string }> }) {
           </div>
         </header>
 
-        {/* Error Summary - Sticky Message Box */}
+        {/* Error Summary - Message Box */}
         {ready && validationErrors.length > 0 && (
-          <div className="sticky top-4 z-50 mb-4">
+          <div className="mb-4">
             <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4 backdrop-blur-sm">
               <div className="flex items-start gap-3">
                 <AlertTriangle className="h-5 w-5 text-yellow-600 mt-0.5 flex-shrink-0" />

--- a/packages/core/modules/Orders/draft_order.tsx
+++ b/packages/core/modules/Orders/draft_order.tsx
@@ -169,7 +169,7 @@ export default function Page(pageProps: { params: Promise<{ id?: string }> }) {
     return (
       <>
         <header className="px-0 pb-2 pt-4 flex justify-between items-center">
-          <span className="text-2xl font-semibold my-2">{`${id === "new" ? "Create" : "Edit"} order`}</span>
+          <span className="text-2xl font-semibold my-2">{`${id === "new" ? "Draft" : "Edit"} order`}</span>
           <div>
             <ButtonField
               type="button"

--- a/packages/core/modules/Orders/draft_order.tsx
+++ b/packages/core/modules/Orders/draft_order.tsx
@@ -57,7 +57,7 @@ export default function Page(pageProps: { params: Promise<{ id?: string }> }) {
     const [ready, setReady] = useState<boolean>(false);
     const [loading, setLoading] = useState<boolean>(false);
     const [key, setKey] = useState<string>(`order-${Date.now()}`);
-
+    const [errorsExpanded, setErrorsExpanded] = useState<boolean>(false);
 
     const { order, current, isNew, DEFAULT_STATE, query, ...mutation } =
       useOrderForm({ id });
@@ -190,20 +190,56 @@ export default function Page(pageProps: { params: Promise<{ id?: string }> }) {
         {/* Error Summary - Message Box */}
         {ready && validationErrors.length > 0 && (
           <div className="mb-4">
-            <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4 backdrop-blur-sm">
-              <div className="flex items-start gap-3">
-                <AlertTriangle className="h-5 w-5 text-yellow-600 mt-0.5 flex-shrink-0" />
-                <div className="flex-1 min-w-0">
-                  <h3 className="text-sm font-medium text-yellow-800 mb-2">
-                    Please address the following errors before saving:
-                  </h3>
-                  <ul className="text-sm text-yellow-700 space-y-1 list-disc list-inside">
-                    {validationErrors.map((error, index) => (
-                      <li key={index}>{error}</li>
-                    ))}
-                  </ul>
+            <div className="bg-yellow-50 border border-yellow-200 rounded-lg backdrop-blur-sm overflow-hidden">
+              <div className="p-4">
+                <div className="flex items-start gap-3">
+                  <AlertTriangle className="h-5 w-5 text-yellow-600 mt-0.5 flex-shrink-0" />
+                  <div className="flex-1 min-w-0">
+                    <h3 className="text-sm font-medium text-yellow-800 mb-2">
+                      Please address the following errors before saving:
+                    </h3>
+                    <ul className={`text-sm text-yellow-700 space-y-1 list-disc list-inside ${
+                      errorsExpanded || validationErrors.length <= 3 
+                        ? '' 
+                        : 'max-h-16 overflow-y-auto'
+                    }`}>
+                      {validationErrors.map((error, index) => (
+                        <li key={index}>{error}</li>
+                      ))}
+                    </ul>
+                  </div>
                 </div>
               </div>
+              {(!errorsExpanded && validationErrors.length > 3) && (
+                <div 
+                  className="bg-yellow-100 border-t border-yellow-200 px-4 py-1.5 cursor-pointer hover:bg-yellow-150 transition-colors"
+                  onClick={() => setErrorsExpanded(!errorsExpanded)}
+                >
+                  <div className="flex items-center justify-between text-xs">
+                    <span className="text-yellow-700">
+                      {`${validationErrors.length - 3} more error${validationErrors.length - 3 > 1 ? 's' : ''} - Click to view all`}
+                    </span>
+                    <span className="text-yellow-700 text-xs">
+                      ▼
+                    </span>
+                  </div>
+                </div>
+              )}
+              {errorsExpanded && validationErrors.length > 3 && (
+                <div 
+                  className="bg-yellow-100 border-t border-yellow-200 px-4 py-1.5 cursor-pointer hover:bg-yellow-150 transition-colors"
+                  onClick={() => setErrorsExpanded(!errorsExpanded)}
+                >
+                  <div className="flex items-center justify-between text-xs">
+                    <span className="text-yellow-700">
+                      Click to collapse errors
+                    </span>
+                    <span className="text-yellow-700 text-xs">
+                      ▲
+                    </span>
+                  </div>
+                </div>
+              )}
             </div>
           </div>
         )}

--- a/packages/core/modules/Orders/index.tsx
+++ b/packages/core/modules/Orders/index.tsx
@@ -296,7 +296,7 @@ export default function OrdersPage() {
           <div className="flex flex-row items-center gap-1 flex-wrap">
             <Button asChild size="sm" className="mx-1 w-auto">
               <AppLink href="/draft_orders/new">
-                Create order
+                Draft order
               </AppLink>
             </Button>
             <Button asChild size="sm" className="mx-1 w-auto">


### PR DESCRIPTION
## Bugfix: Warning Overlap in Draft Order

### Summary
This PR resolves the warning message box overlap issue on the draft order page.  

### Key changes include:  
- Removed sticky property from the warning box.  
- Added max height with expand/collapse functionality for better usability of warning box.  
- Synced scrolling between left and right sections.  
- Fixed issue of excessive white space at bottom when scrolling.
- Updated header text from *"Create Order"* to *"Draft Order"* on the draft order page.  
- Renamed the *"Create Order"* button to *"Draft Order"* on the orders page for consistency.  



