### PR TITLE
fix: Fedex does not create and return commercial invoice

### DIFF
--- a/modules/connectors/fedex/karrio/providers/fedex/shipment/create.py
+++ b/modules/connectors/fedex/karrio/providers/fedex/shipment/create.py
@@ -392,12 +392,6 @@ def shipment_request(
                     ),
                     etdDetail=lib.identity(
                         fedex.EtdDetailType(
-                            attributes=lib.identity(
-                                None
-                                if options.doc_files.state
-                                or options.doc_references.state
-                                else ["POST_SHIPMENT_UPLOAD_REQUESTED"]
-                            ),
                             attachedDocuments=lib.identity(
                                 [
                                     fedex.AttachedDocumentType(
@@ -713,7 +707,7 @@ def shipment_request(
                 )
                 if (
                     customs.commercial_invoice is True
-                    and not packages.options.fedex_electronic_trade_documents.state
+                    or packages.options.fedex_electronic_trade_documents.state
                 )
                 else None
             ),


### PR DESCRIPTION
it seems we have to send `shippingDocumentSpecification` even for `fedex_electronic_trade_documents`, also we need to remove `POST_SHIPMENT_UPLOAD_REQUESTED` as it means that the user will send them the commercial invoice in a later time, not while label creation.