### PR TITLE
UPS: Package number references allowed for US and PR shipments

### DIFF
--- a/modules/sdk/karrio/core/utils/helpers.py
+++ b/modules/sdk/karrio/core/utils/helpers.py
@@ -16,7 +16,7 @@ from typing import List, TypeVar, Callable, Optional, Any, cast
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 logger = logging.getLogger(__name__)
-ssl._create_default_https_context = ssl._create_unverified_context
+ssl._create_default_https_context = ssl._create_unverified_context  # type: ignore
 PIL.ImageFile.LOAD_TRUNCATED_IMAGES = True
 T = TypeVar("T")
 S = TypeVar("S")


### PR DESCRIPTION
Shipment level reference numbers are only valid for **non** US/PR shipments.

Package level reference numbers are only valid **for** US/PR shipments.

Very confusing, but per the UPS docs I believe this is the right way to do it, otherwise its impossible to add reference numbers for UPS US/PR shipments.