### PR TITLE
[fix] dark mode readability in docs

### DIFF
--- a/apps/web/src/app/docs/api-reference/page.tsx
+++ b/apps/web/src/app/docs/api-reference/page.tsx
@@ -20,8 +20,21 @@ declare global {
 }
 
 export default function ApiReferencePage() {
-  const { theme } = useTheme();
+  const { resolvedTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
+  const getStoredTheme = (): 'light' | 'dark' => {
+    if (typeof window === 'undefined') return 'light';
+    try {
+      const stored = window.localStorage.getItem('theme-content');
+      if (stored === 'dark' || stored === 'light') return stored;
+      if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) return 'dark';
+    } catch { }
+    return 'light';
+  };
+  // Revert to light-mode-only code styling (rely on component defaults for dark)
+  useEffect(() => {
+    if (!mounted) return;
+  }, [mounted]);
 
   useEffect(() => {
     setMounted(true);
@@ -30,11 +43,21 @@ export default function ApiReferencePage() {
   return (
     <div className="w-full h-full bg-background dark:bg-neutral-950">
       <elements-api
+        key={(mounted ? (resolvedTheme as 'light' | 'dark' | undefined) : undefined) ?? getStoredTheme()}
         apiDescriptionUrl="/openapi.yml"
         router="hash"
         layout="responsive"
-        theme={mounted ? (theme === 'dark' ? 'dark' : 'light') : 'light'}
-        className="w-full h-[calc(100vh-56px)]"
+        theme={((mounted ? resolvedTheme : undefined) ?? getStoredTheme()) === 'dark' ? 'dark' : 'light'}
+        className="w-full h-[calc(100vh-56px)] custom-docs-theme"
+        data-theme={(mounted ? (resolvedTheme as 'light' | 'dark' | undefined) : undefined) ?? getStoredTheme()}
+        style={{
+          background: 'transparent',
+          // Attempt to override internal surface variables used by some web components
+          ['--color-canvas' as any]: 'transparent',
+          ['--color-bg' as any]: 'transparent',
+          ['--sl-color-bg' as any]: 'transparent',
+          ['--sl-color-surface' as any]: 'transparent'
+        } as React.CSSProperties}
         hideSchemas="true"
         hideTryIt="true"
       />

--- a/apps/web/src/app/docs/developing/carrier-integration/page.mdx
+++ b/apps/web/src/app/docs/developing/carrier-integration/page.mdx
@@ -32,8 +32,7 @@ flowchart TD
     Test --> Validate[Validate Integration]
     Validate --> End([Complete])
 
-    style Start fill:#f9f,stroke:#333,stroke-width:2px
-    style End fill:#9f9,stroke:#333,stroke-width:2px
+    
 ```
 
 ## Prerequisites

--- a/apps/web/src/app/docs/developing/dashboard-guide/developer-tools/page.mdx
+++ b/apps/web/src/app/docs/developing/dashboard-guide/developer-tools/page.mdx
@@ -105,16 +105,11 @@ Direct links to common developer tasks:
 - **Check Logs**: Monitor recent API activity
 - **Configure Webhooks**: Set up event notifications
 
-<div className="bg-blue-50 dark:bg-blue-900 rounded-lg p-4 my-6">
-  <div className="text-sm text-blue-700 dark:text-blue-300 mb-2">
-    💡 Developer Dashboard Benefits
-  </div>
-  <p className="text-sm text-blue-600 dark:text-blue-400">
-    The developer dashboard provides real-time visibility into your integration
-    health, helping you monitor performance, debug issues, and optimize your
-    implementation.
-  </p>
-</div>
+> [!TIP]
+>
+> **Developer Dashboard Benefits**
+>
+> The developer dashboard provides real-time visibility into your integration health, helping you monitor performance, debug issues, and optimize your implementation.
 
 ## API Keys Management
 
@@ -244,16 +239,11 @@ Handle webhook events effectively:
 }
 ```
 
-<div className="bg-orange-50 dark:bg-orange-900 rounded-lg p-4 my-6">
-  <div className="text-sm text-orange-700 dark:text-orange-300 mb-2">
-    ⚠️ Webhook Security
-  </div>
-  <p className="text-sm text-orange-600 dark:text-orange-400">
-    Always validate webhook signatures to ensure events come from Karrio. Store
-    webhook secrets securely and use HTTPS endpoints for receiving
-    notifications.
-  </p>
-</div>
+> [!WARNING]
+>
+> **Webhook Security**
+>
+> Always validate webhook signatures to ensure events come from Karrio. Store webhook secrets securely and use HTTPS endpoints for receiving notifications.
 
 ## API Logs and Monitoring
 
@@ -544,16 +534,11 @@ Built-in debugging assistance:
 - **Endpoint Efficiency**: Choose optimal API endpoints
 - **Batch Processing**: Reduce API call overhead
 
-<div className="bg-blue-50 dark:bg-blue-900 rounded-lg p-4 my-6">
-  <div className="text-sm text-blue-700 dark:text-blue-300 mb-2">
-    💡 Developer Best Practices
-  </div>
-  <p className="text-sm text-blue-600 dark:text-blue-400">
-    Use the developer tools regularly to monitor integration health, debug
-    issues proactively, and optimize performance. Set up appropriate alerts and
-    monitoring to catch issues before they impact users.
-  </p>
-</div>
+> [!TIP]
+>
+> **Developer Best Practices**
+>
+> Use the developer tools regularly to monitor integration health, debug issues proactively, and optimize performance. Set up appropriate alerts and monitoring to catch issues before they impact users.
 
 ## API Usage Optimization
 

--- a/apps/web/src/app/docs/developing/dashboard-guide/document-templates/page.mdx
+++ b/apps/web/src/app/docs/developing/dashboard-guide/document-templates/page.mdx
@@ -142,16 +142,11 @@ Build templates with the visual designer:
 - **Shipping Info**: Carriers, services, tracking
 - **Company Details**: Business information
 
-<div className="bg-blue-50 dark:bg-blue-900 rounded-lg p-4 my-6">
-  <div className="text-sm text-blue-700 dark:text-blue-300 mb-2">
-    💡 Template Variables
-  </div>
-  <p className="text-sm text-blue-600 dark:text-blue-400">
-    Use template variables like `{order.order_id}` or `{customer.name}` to
-    dynamically populate document content. The system automatically replaces
-    these with actual data when generating documents.
-  </p>
-</div>
+> [!TIP]
+>
+> **Template Variables**
+>
+> Use template variables like `{order.order_id}` or `{customer.name}` to dynamically populate document content. The system automatically replaces these with actual data when generating documents.
 
 ## Template Designer Features
 
@@ -302,16 +297,11 @@ Show content based on conditions:
 {{formatTime shipment.pickup_time "h:mm A"}}
 ```
 
-<div className="bg-orange-50 dark:bg-orange-900 rounded-lg p-4 my-6">
-  <div className="text-sm text-orange-700 dark:text-orange-300 mb-2">
-    ⚠️ Data Availability
-  </div>
-  <p className="text-sm text-orange-600 dark:text-orange-400">
-    Template variables depend on the context where the template is used. Not all
-    data is available in every situation. Test templates thoroughly with
-    different data scenarios.
-  </p>
-</div>
+> [!WARNING]
+>
+> **Data Availability**
+>
+> Template variables depend on the context where the template is used. Not all data is available in every situation. Test templates thoroughly with different data scenarios.
 
 ## Template Management
 

--- a/apps/web/src/app/docs/developing/dashboard-guide/label-creation/page.mdx
+++ b/apps/web/src/app/docs/developing/dashboard-guide/label-creation/page.mdx
@@ -125,16 +125,11 @@ Add optional services:
 - **Declared Value**: Custom value declaration
 - **Hold at Location**: Delivery to pickup location
 
-<div className="bg-blue-50 dark:bg-blue-900 rounded-lg p-4 my-6">
-  <div className="text-sm text-blue-700 dark:text-blue-300 mb-2">
-    💡 Smart Defaults
-  </div>
-  <p className="text-sm text-blue-600 dark:text-blue-400">
-    The form remembers your preferences and automatically populates common
-    options like currency, shipping date, and package types based on your
-    previous shipments.
-  </p>
-</div>
+> [!TIP]
+>
+> **Smart Defaults**
+>
+> The form remembers your preferences and automatically populates common options like currency, shipping date, and package types based on your previous shipments.
 
 ### 4. Rate Comparison
 
@@ -211,15 +206,11 @@ For each item in the shipment:
 - **Unit Value**: Price per item
 - **Origin Country**: Country of manufacture
 
-<div className="bg-orange-50 dark:bg-orange-900 rounded-lg p-4 my-6">
-  <div className="text-sm text-orange-700 dark:text-orange-300 mb-2">
-    ⚠️ Customs Accuracy
-  </div>
-  <p className="text-sm text-orange-600 dark:text-orange-400">
-    Accurate customs information is required for international shipments.
-    Incorrect declarations can cause delays, additional fees, or customs holds.
-  </p>
-</div>
+> [!WARNING]
+>
+> **Customs Accuracy**
+>
+> Accurate customs information is required for international shipments. Incorrect declarations can cause delays, additional fees, or customs holds.
 
 ## Payment and Billing
 

--- a/apps/web/src/app/docs/developing/dashboard-guide/page.mdx
+++ b/apps/web/src/app/docs/developing/dashboard-guide/page.mdx
@@ -97,10 +97,6 @@ flowchart TD
     F --> G[Automatic Tracking]
     G --> H[Delivery Updates]
 
-    style A fill:#e1f5fe
-    style D fill:#fff3e0
-    style F fill:#e8f5e8
-    style H fill:#f3e5f5
 ```
 
 ## Best Practices

--- a/apps/web/src/app/docs/developing/dashboard-guide/test-mode/page.mdx
+++ b/apps/web/src/app/docs/developing/dashboard-guide/test-mode/page.mdx
@@ -49,15 +49,11 @@ Test mode uses carrier sandbox APIs and test credentials, allowing you to:
 - **Tracking**: Monitor simulated package deliveries
 - **Error Handling**: Test edge cases and error scenarios
 
-<div className="bg-blue-50 dark:bg-blue-900 rounded-lg p-4 my-6">
-  <div className="text-sm text-blue-700 dark:text-blue-300 mb-2">
-    💡 Test Mode Indicators
-  </div>
-  <p className="text-sm text-blue-600 dark:text-blue-400">
-    Test mode is clearly indicated throughout the dashboard with visual cues
-    including orange badges, test data watermarks, and sandbox API endpoints.
-  </p>
-</div>
+> [!TIP]
+>
+> **Test Mode Indicators**
+>
+> Test mode is clearly indicated throughout the dashboard with visual cues including orange badges, test data watermarks, and sandbox API endpoints.
 
 ### Test Mode Features
 
@@ -241,15 +237,11 @@ Live mode connects to production carrier APIs for real shipping operations:
 - **Tracking Updates**: Real delivery status notifications
 - **Label Printing**: Functional shipping labels
 
-<div className="bg-orange-50 dark:bg-orange-900 rounded-lg p-4 my-6">
-  <div className="text-sm text-orange-700 dark:text-orange-300 mb-2">
-    ⚠️ Production Considerations
-  </div>
-  <p className="text-sm text-orange-600 dark:text-orange-400">
-    Live mode processes real transactions. Ensure your integrations are
-    thoroughly tested in test mode before switching to live operations.
-  </p>
-</div>
+> [!WARNING]
+>
+> **Production Considerations**
+>
+> Live mode processes real transactions. Ensure your integrations are thoroughly tested in test mode before switching to live operations.
 
 ## Switching Between Modes
 

--- a/apps/web/src/app/docs/developing/dashboard-guide/trackers/page.mdx
+++ b/apps/web/src/app/docs/developing/dashboard-guide/trackers/page.mdx
@@ -125,15 +125,11 @@ Karrio supports tracking from major carriers:
 - **Canada Post**: Domestic and international services
 - **And many more**: Regional and specialty carriers
 
-<div className="bg-blue-50 dark:bg-blue-900 rounded-lg p-4 my-6">
-  <div className="text-sm text-blue-700 dark:text-blue-300 mb-2">
-    💡 Smart Carrier Detection
-  </div>
-  <p className="text-sm text-blue-600 dark:text-blue-400">
-    Karrio can often detect the carrier automatically based on tracking number
-    format, making the tracking setup process faster and more accurate.
-  </p>
-</div>
+> [!TIP]
+>
+> **Smart Carrier Detection**
+>
+> Karrio can often detect the carrier automatically based on tracking number format, making the tracking setup process faster and more accurate.
 
 ## Tracking Status Codes
 
@@ -261,16 +257,11 @@ Trackers automatically link with:
 - **Customer Updates**: Automatic tracking notifications
 - **Delivery Confirmation**: Order completion tracking
 
-<div className="bg-orange-50 dark:bg-orange-900 rounded-lg p-4 my-6">
-  <div className="text-sm text-orange-700 dark:text-orange-300 mb-2">
-    ⚠️ Tracking Limitations
-  </div>
-  <p className="text-sm text-orange-600 dark:text-orange-400">
-    Tracking accuracy depends on carrier data quality and update frequency. Some
-    carriers provide more detailed information than others, and rural deliveries
-    may have fewer tracking events.
-  </p>
-</div>
+> [!WARNING]
+>
+> **Tracking Limitations**
+>
+> Tracking accuracy depends on carrier data quality and update frequency. Some carriers provide more detailed information than others, and rural deliveries may have fewer tracking events.
 
 ## Analytics and Reporting
 

--- a/apps/web/src/app/docs/platform/app-store/api-integration/page.mdx
+++ b/apps/web/src/app/docs/platform/app-store/api-integration/page.mdx
@@ -43,7 +43,7 @@ Karrio provides comprehensive APIs that allow your apps to:
 Karrio offers multiple API interfaces to suit different use cases:
 
 ```mermaid
-graph TB
+graph LR
     A[Your Karrio App] --> B[Authentication Layer]
     B --> C[GraphQL API]
     B --> D[REST API v1]
@@ -61,10 +61,7 @@ graph TB
     E --> M[Real-time Updates]
     E --> N[Event Notifications]
 
-    style A fill:#e3f2fd
-    style C fill:#e8f5e8
-    style D fill:#fff3e0
-    style E fill:#fce4ec
+    
 ```
 
 ## GraphQL API

--- a/apps/web/src/app/docs/platform/app-store/deployment/page.mdx
+++ b/apps/web/src/app/docs/platform/app-store/deployment/page.mdx
@@ -32,7 +32,7 @@ Learn how to deploy your Karrio Apps to production with confidence, including te
 Karrio Apps can be deployed in several ways depending on your architecture and requirements:
 
 ```mermaid
-graph TB
+graph LR
     A[Development] --> B[Testing]
     B --> C[Staging]
     C --> D[Production]
@@ -67,10 +67,7 @@ graph TB
     C --> K
     D --> N
 
-    style A fill:#e3f2fd
-    style B fill:#e8f5e8
-    style C fill:#fff3e0
-    style D fill:#fce4ec
+    
 ```
 
 ## Development Setup

--- a/apps/web/src/app/docs/platform/app-store/page.mdx
+++ b/apps/web/src/app/docs/platform/app-store/page.mdx
@@ -226,10 +226,7 @@ graph TB
     C --> J
     F --> K
 
-    style A fill:#e3f2fd
-    style B fill:#e8f5e8
-    style C fill:#fff3e0
-    style D fill:#fce4ec
+    
 ```
 
 ## Key Features

--- a/apps/web/src/app/docs/platform/quickstart/page.mdx
+++ b/apps/web/src/app/docs/platform/quickstart/page.mdx
@@ -21,7 +21,11 @@ After completing the [installation](../setup), access your Karrio instance:
 
 ![Initial Login Screen](/placeholder.svg)
 
-> ⚠️ **Important**: Change these default credentials immediately after your first login.
+> [!WARNING]
+>
+> **Important**
+>
+> Change these default credentials immediately after your first login.
 
 ## Setting Up Your Superadmin Account
 

--- a/apps/web/src/app/docs/products/admin-console/page.mdx
+++ b/apps/web/src/app/docs/products/admin-console/page.mdx
@@ -68,7 +68,7 @@ Advanced security controls including access policies, audit logs, and compliance
 ### Admin Console Architecture
 
 ```mermaid
-flowchart TD
+flowchart LR
     A[Admin User] --> B[Authentication Layer]
     B --> C[Authorization Check]
     C --> D[Admin Dashboard]
@@ -99,9 +99,7 @@ flowchart TD
     L --> U
     O --> U
 
-    style A fill:#e1f5fe
-    style B fill:#fff3e0
-    style U fill:#e8f5e8
+    
 ```
 
 ## API Reference

--- a/apps/web/src/app/docs/products/api-logs/page.mdx
+++ b/apps/web/src/app/docs/products/api-logs/page.mdx
@@ -89,12 +89,7 @@ flowchart TD
     O[Compliance Auditor] --> E
     P[Data Retention] --> E
 
-    style A fill:#e1f5fe
-    style E fill:#fff3e0
-    style G fill:#fff3e0
-    style H fill:#e8f5e8
-    style I fill:#e8f5e8
-    style J fill:#e8f5e8
+    
 ```
 
 ## API Reference

--- a/apps/web/src/app/docs/products/app-store/api-integration/page.mdx
+++ b/apps/web/src/app/docs/products/app-store/api-integration/page.mdx
@@ -61,10 +61,7 @@ graph TB
     E --> M[Real-time Updates]
     E --> N[Event Notifications]
 
-    style A fill:#e3f2fd
-    style C fill:#e8f5e8
-    style D fill:#fff3e0
-    style E fill:#fce4ec
+    
 ```
 
 ## GraphQL API

--- a/apps/web/src/app/docs/products/app-store/deployment/page.mdx
+++ b/apps/web/src/app/docs/products/app-store/deployment/page.mdx
@@ -67,10 +67,7 @@ graph TB
     C --> K
     D --> N
 
-    style A fill:#e3f2fd
-    style B fill:#e8f5e8
-    style C fill:#fff3e0
-    style D fill:#fce4ec
+    
 ```
 
 ## Development Setup

--- a/apps/web/src/app/docs/products/batch-processing/page.mdx
+++ b/apps/web/src/app/docs/products/batch-processing/page.mdx
@@ -93,11 +93,7 @@ flowchart TD
     Q --> R[Failed Operations]
     R --> S[Manual Review]
 
-    style A fill:#e1f5fe
-    style K fill:#fff3e0
-    style N fill:#e8f5e8
-    style O fill:#e8f5e8
-    style P fill:#ffebee
+    
 ```
 
 ## API Reference

--- a/apps/web/src/app/docs/products/carrier-connections/page.mdx
+++ b/apps/web/src/app/docs/products/carrier-connections/page.mdx
@@ -75,10 +75,7 @@ flowchart TD
     N --> B
     B --> A
 
-    style A fill:#e1f5fe
-    style B fill:#fff3e0
-    style M fill:#e8f5e8
-    style N fill:#e8f5e8
+    
 ```
 
 ### Core Components

--- a/apps/web/src/app/docs/products/document-generation/page.mdx
+++ b/apps/web/src/app/docs/products/document-generation/page.mdx
@@ -32,21 +32,11 @@ Generate documents using templates with dynamic data injection and multiple outp
 
 Specialized support for GS1 barcode labels with compliant formatting and encoding.
 
-<div className="bg-blue-50 dark:bg-blue-900 rounded-lg p-4 my-6">
-  <div className="flex items-center gap-2 mb-2">
-    <div className="w-4 h-4 bg-blue-500 rounded-full flex items-center justify-center">
-      <span className="text-white text-xs">ℹ</span>
-    </div>
-    <div className="text-sm font-medium text-blue-900 dark:text-blue-100">
-      Shipping Labels
-    </div>
-  </div>
-  <div className="text-sm text-blue-700 dark:text-blue-300">
-    Shipping labels are automatically generated when creating shipments and
-    don't require the document generation API. They support PDF, PNG, and ZPL
-    formats.
-  </div>
-</div>
+> [!TIP]
+>
+> **Shipping Labels**
+>
+> Shipping labels are automatically generated when creating shipments and don't require the document generation API. They support PDF, PNG, and ZPL formats.
 
 ## API Reference
 

--- a/apps/web/src/app/docs/products/events/page.mdx
+++ b/apps/web/src/app/docs/products/events/page.mdx
@@ -88,12 +88,7 @@ flowchart TD
     P[Event Transformers] --> E
     Q[Dead Letter Queue] --> R[Failed Events]
 
-    style A fill:#e1f5fe
-    style C fill:#fff3e0
-    style E fill:#fff3e0
-    style K fill:#e8f5e8
-    style M fill:#e8f5e8
-    style R fill:#ffebee
+    
 ```
 
 ## API Reference

--- a/apps/web/src/app/docs/products/multi-orgs/page.mdx
+++ b/apps/web/src/app/docs/products/multi-orgs/page.mdx
@@ -79,10 +79,7 @@ flowchart TD
     M --> Q[Isolated Orders]
     N --> R[Complete Data Separation]
 
-    style A fill:#e1f5fe
-    style G fill:#fff3e0
-    style R fill:#e8f5e8
-    style J fill:#f3e5f5
+    
 ```
 
 ### Authentication Flow
@@ -111,9 +108,7 @@ flowchart TD
     L --> M[Permission Validation]
     M --> N[Resource Access]
 
-    style A fill:#e1f5fe
-    style L fill:#fff3e0
-    style N fill:#e8f5e8
+    
 ```
 
 ## Core Features

--- a/apps/web/src/app/docs/products/orders/page.mdx
+++ b/apps/web/src/app/docs/products/orders/page.mdx
@@ -92,10 +92,7 @@ flowchart TD
     R --> S[Status Tracking]
     R --> T[Metadata Updates]
 
-    style A fill:#e1f5fe
-    style F fill:#e8f5e8
-    style L fill:#fff3e0
-    style P fill:#f3e5f5
+    
 ```
 
 ## API Reference
@@ -766,10 +763,7 @@ flowchart TD
     B --> G
     C --> D[delivered]
 
-    style A fill:#fff3e0
-    style C fill:#e8f5e8
-    style D fill:#e1f5fe
-    style G fill:#ffebee
+    
 ```
 
 ## Use Cases

--- a/apps/web/src/app/docs/products/shipments/international/page.mdx
+++ b/apps/web/src/app/docs/products/shipments/international/page.mdx
@@ -46,10 +46,7 @@ flowchart TD
     J --> K[Customs Clearance]
     K --> L[Delivery]
 
-    style A fill:#e1f5fe
-    style B fill:#fff3e0
-    style E fill:#e8f5e8
-    style K fill:#f3e5f5
+    
 ```
 
 ## API Reference

--- a/apps/web/src/app/docs/products/shipments/label-generation/page.mdx
+++ b/apps/web/src/app/docs/products/shipments/label-generation/page.mdx
@@ -49,10 +49,7 @@ flowchart TD
 
     K --> L[Shipment Fulfillment]
 
-    style A fill:#e1f5fe
-    style C fill:#fff3e0
-    style E fill:#e8f5e8
-    style K fill:#f3e5f5
+    
 ```
 
 ## API Reference

--- a/apps/web/src/app/docs/products/shipments/live-rates/page.mdx
+++ b/apps/web/src/app/docs/products/shipments/live-rates/page.mdx
@@ -47,10 +47,7 @@ flowchart TD
     H --> I[Service Selection]
     I --> J[Label Purchase]
 
-    style A fill:#e1f5fe
-    style G fill:#e8f5e8
-    style H fill:#fff3e0
-    style I fill:#f3e5f5
+    
 ```
 
 ## API Reference

--- a/apps/web/src/app/docs/products/shipments/page.mdx
+++ b/apps/web/src/app/docs/products/shipments/page.mdx
@@ -172,10 +172,7 @@ flowchart TD
     G --> H[Tracking Setup]
     H --> I[Fulfillment]
 
-    style A fill:#e1f5fe
-    style C fill:#fff3e0
-    style F fill:#e8f5e8
-    style I fill:#f3e5f5
+    
 ```
 
 ## Common Use Cases

--- a/apps/web/src/app/docs/products/shipments/paperless-trade/page.mdx
+++ b/apps/web/src/app/docs/products/shipments/paperless-trade/page.mdx
@@ -316,10 +316,7 @@ flowchart TD
     I --> J
     J --> K[Electronic Customs Processing]
 
-    style A fill:#e1f5fe
-    style K fill:#e8f5e8
-    style H fill:#fff3e0
-    style I fill:#f3e5f5
+    
 ```
 
 ## Best Practices

--- a/apps/web/src/app/docs/products/shipping-rules/page.mdx
+++ b/apps/web/src/app/docs/products/shipping-rules/page.mdx
@@ -109,10 +109,7 @@ flowchart TD
 
     S --> T[Shipment Creation]
 
-    style A fill:#e1f5fe
-    style L fill:#fff3e0
-    style S fill:#e8f5e8
-    style T fill:#e8f5e8
+    
 ```
 
 ## API Reference

--- a/apps/web/src/app/docs/products/tracking/page.mdx
+++ b/apps/web/src/app/docs/products/tracking/page.mdx
@@ -101,10 +101,7 @@ flowchart TD
     M --> P[Client Applications]
     L --> Q[Database Updates]
 
-    style A fill:#e1f5fe
-    style L fill:#e8f5e8
-    style M fill:#fff3e0
-    style N fill:#f3e5f5
+    
 ```
 
 ## API Reference

--- a/apps/web/src/app/docs/products/user-management/page.mdx
+++ b/apps/web/src/app/docs/products/user-management/page.mdx
@@ -91,12 +91,7 @@ flowchart TD
     O --> Q[Return Response]
     P --> R[Return Error]
 
-    style A fill:#e1f5fe
-    style D fill:#fff3e0
-    style O fill:#e8f5e8
-    style E fill:#ffebee
-    style P fill:#ffebee
-    style R fill:#ffebee
+    
 ```
 
 ## API Reference

--- a/apps/web/src/app/docs/products/webhooks/page.mdx
+++ b/apps/web/src/app/docs/products/webhooks/page.mdx
@@ -88,10 +88,7 @@ flowchart TD
     P[Signature Verification] --> G
     Q[Event Logging] --> R[Analytics]
 
-    style A fill:#e1f5fe
-    style G fill:#fff3e0
-    style I fill:#e8f5e8
-    style M fill:#ffebee
+    
 ```
 
 ## API Reference

--- a/apps/web/src/app/docs/products/workflows/page.mdx
+++ b/apps/web/src/app/docs/products/workflows/page.mdx
@@ -101,10 +101,7 @@ flowchart TD
     P --> Q[Webhook Distribution]
     Q --> R[Platform Tracking Updates]
 
-    style A fill:#e1f5fe
-    style C fill:#fff3e0
-    style E fill:#e8f5e8
-    style I fill:#f3e5f5
+    
 ```
 
 ## Platform Integrations

--- a/apps/web/src/app/docs/self-hosting/page.mdx
+++ b/apps/web/src/app/docs/self-hosting/page.mdx
@@ -52,11 +52,8 @@ graph TB
     Worker --> Carriers
     API --> Carriers
 
-    %% Styling
-    classDef frontend fill:#e1f5fe
-    classDef backend fill:#f3e5f5
-    classDef data fill:#e8f5e8
-    classDef external fill:#fff3e0
+    
+    
 
     class Dashboard frontend
     class API,Worker backend
@@ -210,10 +207,7 @@ graph LR
     W2 --> Redis
     W3 --> DB
 
-    classDef api fill:#f3e5f5
-    classDef worker fill:#e1f5fe
-    classDef data fill:#e8f5e8
-    classDef lb fill:#fce4ec
+    
 
     class API1,API2,API3 api
     class W1,W2,W3 worker

--- a/apps/web/src/components/nextra/api-theme.tsx
+++ b/apps/web/src/components/nextra/api-theme.tsx
@@ -116,7 +116,7 @@ export const ApiTheme: FC<{
       attribute="class"
       defaultTheme="system"
       enableSystem
-      storageKey="karrio-docs-theme"
+      storageKey="theme-content"
       enableColorScheme
       disableTransitionOnChange
       themes={['light', 'dark']}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -85,7 +85,8 @@
     --muted: 252 16% 26%;
     --muted-foreground: 0 0% 90%;
     /* Improved from 70% to 90% for better contrast */
-    --accent: 16 100% 50%;
+    /* Use blue accent in dark mode to avoid orange/red outlines on hover */
+    --accent: 217 91% 60%;
     --accent-foreground: 0 0% 100%;
     --destructive: 0 84% 60%;
     --destructive-foreground: 0 0% 100%;
@@ -211,16 +212,18 @@
   /* Ensure links have good visibility and contrast */
   .dark .prose a,
   [data-theme="dark"] .prose a {
-    color: #a78bfa;
+    color: #60a5fa;
+    /* blue-400 */
     /* Purple that matches the brand */
     text-decoration-color: #a78bfa;
   }
 
   .dark .prose a:hover,
   [data-theme="dark"] .prose a:hover {
-    color: #c4b5fd;
-    /* Lighter purple on hover */
-    text-decoration-color: #c4b5fd;
+    color: #93c5fd;
+    /* blue-300 */
+    /* Lighter blue on hover */
+    text-decoration-color: #93c5fd;
   }
 
   /* Style for code and pre-formatted text */
@@ -317,7 +320,7 @@ html[data-theme="dark"] * {
 .DocSearch-Button:hover,
 .DocSearch-Button:focus {
   background-color: hsl(var(--accent));
-  border-color: hsl(var(--accent-foreground) / 20%);
+  border-color: hsl(var(--accent) / 40%);
   outline: none;
 }
 
@@ -807,6 +810,28 @@ html[data-theme="dark"] * {
   border-color: #27272a !important;
 }
 
+/* Improve dark-mode code token contrast in regular docs code blocks */
+.dark pre code .token.builtin,
+.dark pre code .token.function,
+.dark pre code .token.command,
+[data-theme="dark"] pre code .token.builtin,
+[data-theme="dark"] pre code .token.function,
+[data-theme="dark"] pre code .token.command {
+  color: #7dd3fc !important;
+  /* sky-300 for readability */
+}
+
+.dark pre code .token.keyword,
+[data-theme="dark"] pre code .token.keyword {
+  color: #7dd3fc !important;
+}
+
+.dark pre code .token.string,
+[data-theme="dark"] pre code .token.string {
+  color: #86efac !important;
+  /* emerald-300 */
+}
+
 /* Ensure inline code styling is consistent across blog and docs */
 .dark .prose code:not([class*="language-"]),
 [data-theme="dark"] .prose code:not([class*="language-"]),
@@ -1112,6 +1137,319 @@ div.nextra-callout:not([data-type="info"]):not([data-type="note"]):not([data-typ
 [data-theme="dark"] .text-gray-900 {
   color: #f3f4f6 !important;
   /* Light gray with good contrast */
+}
+
+/* #endregion */
+
+/* Dark mode table readability in docs (prose) */
+.dark .prose table th,
+.dark .prose table td,
+[data-theme="dark"] .prose table th,
+[data-theme="dark"] .prose table td {
+  color: hsl(var(--foreground)) !important;
+}
+
+/* Ensure API reference web component background adapts */
+.dark elements-api,
+[data-theme="dark"] elements-api {
+  background: transparent !important;
+}
+
+/* Host-level theme vars for Spotlight Elements (apply when we add class on host) */
+elements-api.custom-docs-theme {
+  /* Light theme defaults */
+  --sl-color-text: #1f2937;
+  --sl-color-bg: #f8f9fc;
+}
+
+.dark elements-api.custom-docs-theme,
+[data-theme="dark"] elements-api.custom-docs-theme {
+  /* High contrast dark */
+  --sl-color-text: #e2e8f0;
+  --sl-color-bg: #0f0c24;
+  /* If Spotlight Elements maps code tokens to vars, set them here as discovered */
+  /* Example guesses; harmless if unused */
+  --sl-color-code-text: #e2e8f0;
+  --sl-color-code-bg: #0f0c24;
+  --sl-color-code-kw: #7dd3fc;
+  /* keywords/commands */
+  --sl-color-code-str: #86efac;
+  /* strings */
+  --sl-color-code-num: #fca5a5;
+  /* numbers */
+  --sl-color-code-fn: #fbbf24;
+  /* functions */
+  --sl-color-code-comment: #94a3b8;
+  /* comments */
+}
+
+/* Common internal tokens for Elements API or similar web components */
+.dark elements-api * {
+  --color-canvas: transparent !important;
+  --color-bg: transparent !important;
+  --sl-color-bg: transparent !important;
+  --sl-color-surface: transparent !important;
+}
+
+/* High-contrast code colors inside Stoplight Elements (light DOM) */
+/* Light theme */
+.docs-page .sl-elements pre,
+.docs-page .sl-elements code {
+  background-color: #f8f9fc !important;
+  color: #1f2937 !important;
+}
+
+.docs-page .sl-elements .token.keyword,
+.docs-page .sl-elements .token.tag,
+.docs-page .sl-elements .token.selector,
+.docs-page .sl-elements .token.builtin,
+.docs-page .sl-elements .token.operator,
+.docs-page .sl-elements .token.function,
+.docs-page .sl-elements .token.command {
+  color: #1d4ed8 !important;
+}
+
+.docs-page .sl-elements .token.string,
+.docs-page .sl-elements .token.attr-value {
+  color: #047857 !important;
+}
+
+.docs-page .sl-elements .token.number {
+  color: #b91c1c !important;
+}
+
+/* Light: booleans/constants */
+.docs-page .sl-elements .token.boolean,
+.docs-page .sl-elements .token.constant {
+  color: #b45309 !important;
+}
+
+.docs-page .sl-elements .token.comment {
+  color: #64748b !important;
+}
+
+.docs-page .sl-elements .token.punctuation {
+  color: #1f2937 !important;
+}
+
+/* Dark theme */
+.dark .sl-elements pre,
+.dark .sl-elements code,
+.docs-page [data-theme="dark"] .sl-elements pre,
+.docs-page [data-theme="dark"] .sl-elements code {
+  background-color: #0f0c24 !important;
+  color: #e2e8f0 !important;
+}
+
+.dark .sl-elements .token.keyword,
+.dark .sl-elements .token.tag,
+.dark .sl-elements .token.selector,
+.dark .sl-elements .token.builtin,
+.dark .sl-elements .token.operator,
+.dark .sl-elements .token.function,
+.dark .sl-elements .token.command,
+.docs-page [data-theme="dark"] .sl-elements .token.keyword,
+.docs-page [data-theme="dark"] .sl-elements .token.tag,
+.docs-page [data-theme="dark"] .sl-elements .token.selector,
+.docs-page [data-theme="dark"] .sl-elements .token.builtin,
+.docs-page [data-theme="dark"] .sl-elements .token.operator,
+.docs-page [data-theme="dark"] .sl-elements .token.function,
+.docs-page [data-theme="dark"] .sl-elements .token.command {
+  color: #7dd3fc !important;
+}
+
+.dark .sl-elements .token.string,
+.docs-page [data-theme="dark"] .sl-elements .token.string,
+.dark .sl-elements .token.attr-value,
+.docs-page [data-theme="dark"] .sl-elements .token.attr-value {
+  color: #86efac !important;
+}
+
+/* JSON keys and attributes (Prism JSON often uses .property / .attr-name / .key) */
+.dark .sl-elements .token.property,
+.docs-page [data-theme="dark"] .sl-elements .token.property,
+.dark .sl-elements .token.attr-name,
+.docs-page [data-theme="dark"] .sl-elements .token.attr-name,
+.dark .sl-elements .token.key,
+.docs-page [data-theme="dark"] .sl-elements .token.key {
+  color: #86efac !important;
+}
+
+.dark .sl-elements .token.number,
+.docs-page [data-theme="dark"] .sl-elements .token.number {
+  color: #fca5a5 !important;
+}
+
+/* Dark: booleans/constants */
+.dark .sl-elements .token.boolean,
+.docs-page [data-theme="dark"] .sl-elements .token.boolean,
+.dark .sl-elements .token.constant,
+.docs-page [data-theme="dark"] .sl-elements .token.constant {
+  color: #fbbf24 !important;
+}
+
+.dark .sl-elements .token.comment,
+.docs-page [data-theme="dark"] .sl-elements .token.comment {
+  color: #94a3b8 !important;
+}
+
+.dark .sl-elements .token.punctuation,
+.docs-page [data-theme="dark"] .sl-elements .token.punctuation {
+  color: #e2e8f0 !important;
+}
+
+/* Improve visibility of Stoplight Elements "required" warning labels in dark mode */
+.dark .sl-elements .sl-text-warning,
+.docs-page [data-theme="dark"] .sl-elements .sl-text-warning,
+.dark .sl-elements .text-warning,
+.docs-page [data-theme="dark"] .sl-elements .text-warning {
+  color: #f59e0b !important;
+  /* vibrant amber-500 */
+}
+
+/* #region Docs Callout Helpers (force consistent backgrounds in dark mode) */
+.prose .docs-callout-info,
+.docs-callout-info {
+  background-color: var(--callout-info-bg) !important;
+  border: 1px solid var(--callout-info-border) !important;
+}
+
+.prose .docs-callout-warning,
+.docs-callout-warning {
+  background-color: var(--callout-warning-bg) !important;
+  border: 1px solid var(--callout-warning-border) !important;
+}
+
+.prose .docs-callout-default,
+.docs-callout-default {
+  background-color: var(--callout-bg) !important;
+  border: 1px solid var(--callout-border) !important;
+}
+
+/* Ensure text remains legible inside custom callouts */
+.prose .docs-callout-info *,
+.docs-callout-info * {
+  color: var(--callout-info-text) !important;
+}
+
+.prose .docs-callout-warning *,
+.docs-callout-warning * {
+  color: var(--callout-warning-text) !important;
+}
+
+.prose .docs-callout-default *,
+.docs-callout-default * {
+  color: var(--callout-text) !important;
+}
+
+/* #endregion */
+
+/* #region Legacy light background overrides in dark mode
+   Ensure elements using light Tailwind backgrounds remain readable in dark mode */
+.dark .prose .bg-white,
+[data-theme="dark"] .prose .bg-white {
+  background-color: var(--doc-card-bg) !important;
+}
+
+.dark .prose .bg-gray-50,
+[data-theme="dark"] .prose .bg-gray-50 {
+  background-color: hsl(var(--muted)) !important;
+}
+
+.dark .prose .bg-blue-50,
+[data-theme="dark"] .prose .bg-blue-50 {
+  background-color: #1e3a8a !important;
+  /* blue-900 */
+}
+
+.dark .prose .bg-green-50,
+[data-theme="dark"] .prose .bg-green-50 {
+  background-color: #064e3b !important;
+  /* green-900 */
+}
+
+.dark .prose .bg-red-50,
+[data-theme="dark"] .prose .bg-red-50 {
+  background-color: #7f1d1d !important;
+  /* red-900 */
+}
+
+.dark .prose .bg-yellow-50,
+[data-theme="dark"] .prose .bg-yellow-50 {
+  background-color: #713f12 !important;
+  /* yellow/amber-900 */
+}
+
+.dark .prose .bg-orange-50,
+[data-theme="dark"] .prose .bg-orange-50 {
+  background-color: #7c2d12 !important;
+  /* orange-900 */
+}
+
+.dark .prose .bg-amber-50,
+[data-theme="dark"] .prose .bg-amber-50 {
+  background-color: #78350f !important;
+  /* amber-900 */
+}
+
+.dark .prose .bg-emerald-50,
+[data-theme="dark"] .prose .bg-emerald-50 {
+  background-color: #064e3b !important;
+  /* emerald-900 */
+}
+
+.dark .prose .bg-teal-50,
+[data-theme="dark"] .prose .bg-teal-50 {
+  background-color: #134e4a !important;
+  /* teal-900 */
+}
+
+.dark .prose .bg-cyan-50,
+[data-theme="dark"] .prose .bg-cyan-50 {
+  background-color: #164e63 !important;
+  /* cyan-900 */
+}
+
+.dark .prose .bg-sky-50,
+[data-theme="dark"] .prose .bg-sky-50 {
+  background-color: #0c4a6e !important;
+  /* sky-900 */
+}
+
+.dark .prose .bg-indigo-50,
+[data-theme="dark"] .prose .bg-indigo-50 {
+  background-color: #312e81 !important;
+  /* indigo-900 */
+}
+
+.dark .prose .bg-violet-50,
+[data-theme="dark"] .prose .bg-violet-50 {
+  background-color: #3b0764 !important;
+  /* violet-950 */
+}
+
+.dark .prose .bg-purple-50,
+[data-theme="dark"] .prose .bg-purple-50 {
+  background-color: #581c87 !important;
+  /* purple-900 */
+}
+
+.dark .prose .bg-fuchsia-50,
+[data-theme="dark"] .prose .bg-fuchsia-50 {
+  background-color: #701a75 !important;
+  /* fuchsia-900 */
+}
+
+.dark .prose .bg-pink-50,
+[data-theme="dark"] .prose .bg-pink-50 {
+  background-color: #831843 !important;
+  /* pink-900 */
+}
+
+.dark .prose .bg-rose-50,
+[data-theme="dark"] .prose .bg-rose-50 {
+  background-color: #7f1d1d !important;
+  /* rose-900 */
 }
 
 /* #endregion */


### PR DESCRIPTION
## Changes

### Fixes

- Fixed mermaid graphs dark mode contrast
- Fixed to use themed admonitions across whole docs
- Fixed screenshot canvas contrast in dark mode
- Fixed API reference page dark mode
- Fixed API reference text contrast issues in both dark and light mode
- Fixed Dark/Light mode to carry through docs and continue into API Reference page
- Fixed contrast issue for table headers in dark mode
- Changed hover outline in dark mode from red to blue