### PR TITLE
Refactor/tracker preview modal to sheet

### DIFF
--- a/packages/core/modules/Trackers/index.tsx
+++ b/packages/core/modules/Trackers/index.tsx
@@ -6,7 +6,7 @@ import {
 import {
   TrackingPreview,
   useTrackingPreview,
-} from "@karrio/core/components/tracking-preview";
+} from "@karrio/ui/components/tracking-preview-sheet";
 import { DeleteConfirmationDialog } from "@karrio/ui/components/delete-confirmation-dialog";
 import {
   formatRef,

--- a/packages/ui/components/tracking-preview-sheet.tsx
+++ b/packages/ui/components/tracking-preview-sheet.tsx
@@ -133,10 +133,10 @@ export const TrackingPreview = ({
   };
 
   const getStatusIcon = (status?: string) => {
-    if (status === "delivered") return <CheckCircle className="h-5 w-5" />;
-    if (status === "in_transit") return <Truck className="h-5 w-5" />;
-    if (status === "out_for_delivery") return <Package className="h-5 w-5" />;
-    return <Clock className="h-5 w-5" />;
+    if (status === "delivered") return <CheckCircle className="h-4 w-4" />;
+    if (status === "in_transit") return <Truck className="h-4 w-4" />;
+    if (status === "out_for_delivery") return <Package className="h-4 w-4" />;
+    return <Clock className="h-4 w-4" />;
   };
 
   const getEventIcon = (description?: string) => {
@@ -188,24 +188,24 @@ export const TrackingPreview = ({
               {!isNone(tracker) && (
                 <div className="space-y-6">
                   {/* Carrier Image & Tracking Number */}
-                  <div className="flex items-center justify-center gap-6 mb-6">
+                  <div className="flex items-center justify-center gap-4 mb-4">
                     <div className="flex-shrink-0">
                       <CarrierImage
                         carrier_name={
                           (tracker?.meta as any)?.carrier || tracker?.carrier_name
                         }
-                        width={80}
-                        height={80}
+                        width={65}
+                        height={65}
                         text_color={tracker?.tracking_carrier?.config?.text_color}
                         background={tracker?.tracking_carrier?.config?.brand_color}
                       />
                     </div>
                     <div className="text-center">
-                      <div className="flex justify-center items-center gap-2 text-sm text-gray-500 mb-3">
-                        <Package className="h-4 w-4" />
+                      <div className="flex justify-center items-center gap-1 text-sm text-gray-500 mb-2">
+                        <Package className="h-3.5 w-3.5" />
                         <span>Tracking Number</span>
                       </div>
-                      <div className="font-mono text-xl font-bold text-gray-900 bg-gray-50 px-6 py-3 rounded-lg">
+                      <div className="font-mono text-xl font-bold text-gray-900 bg-gray-50 px-4 py-2 rounded">
                         {tracker?.tracking_number}
                       </div>
                     </div>
@@ -224,8 +224,8 @@ export const TrackingPreview = ({
                   )}
 
                   {/* Status Badge */}
-                  <div className={`${computeColor(tracker as TrackerType)} text-white text-center py-3 rounded-lg`}>
-                    <div className="flex items-center justify-center gap-2 text-xl font-semibold">
+                  <div className={`${computeColor(tracker as TrackerType)} text-white text-center py-2 rounded`}>
+                    <div className="flex items-center justify-center gap-2 text-sm font-medium">
                       {getStatusIcon(tracker?.status)}
                       {computeStatus(tracker as TrackerType)}
                     </div>

--- a/packages/ui/components/tracking-preview-sheet.tsx
+++ b/packages/ui/components/tracking-preview-sheet.tsx
@@ -320,7 +320,7 @@ export const TrackingPreview = ({
                       <h3 className="text-lg font-semibold">Shipment Details</h3>
 
                       {/* Origin/Destination */}
-                      <div className="grid grid-cols-3 gap-4 items-center">
+                      <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 sm:gap-4 sm:items-center">
                         <div className="text-sm text-gray-600">Origin/Destination</div>
                         <div className="col-span-2 text-sm font-medium flex items-center gap-2">
                           <span>{formatAddressRegion(tracker?.shipment?.shipper as any)}</span>
@@ -330,7 +330,7 @@ export const TrackingPreview = ({
                       </div>
 
                       {/* Service */}
-                      <div className="grid grid-cols-3 gap-4 items-center">
+                      <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 sm:gap-4 sm:items-center">
                         <div className="text-sm text-gray-600">Service</div>
                         <div className="col-span-2 text-sm font-medium">
                           {formatRef(
@@ -343,7 +343,7 @@ export const TrackingPreview = ({
 
                       {/* Reference */}
                       {tracker?.shipment?.reference && (
-                        <div className="grid grid-cols-3 gap-4 items-center">
+                        <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 sm:gap-4 sm:items-center">
                           <div className="text-sm text-gray-600">Reference</div>
                           <div className="col-span-2 text-sm font-medium">
                             {tracker?.shipment?.reference}
@@ -352,7 +352,7 @@ export const TrackingPreview = ({
                       )}
 
                       {/* Link */}
-                      <div className="grid grid-cols-3 gap-4 items-center">
+                      <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 sm:gap-4 sm:items-center">
                         <div className="text-sm text-gray-600">Link</div>
                         <div className="col-span-2">
                           <AppLink

--- a/packages/ui/components/tracking-preview-sheet.tsx
+++ b/packages/ui/components/tracking-preview-sheet.tsx
@@ -132,6 +132,13 @@ export const TrackingPreview = ({
     );
   };
 
+  const getStatusIcon = (status?: string) => {
+    if (status === "delivered") return <CheckCircle className="h-5 w-5" />;
+    if (status === "in_transit") return <Truck className="h-5 w-5" />;
+    if (status === "out_for_delivery") return <Package className="h-5 w-5" />;
+    return <Clock className="h-5 w-5" />;
+  };
+
   const getEventIcon = (description?: string) => {
     const desc = description?.toLowerCase() || "";
     if (desc.includes("delivered") || desc.includes("parcel locker")) {
@@ -218,9 +225,10 @@ export const TrackingPreview = ({
 
                   {/* Status Badge */}
                   <div className={`${computeColor(tracker as TrackerType)} text-white text-center py-3 rounded-lg`}>
-                    <p className="text-xl font-semibold">
+                    <div className="flex items-center justify-center gap-2 text-xl font-semibold">
+                      {getStatusIcon(tracker?.status)}
                       {computeStatus(tracker as TrackerType)}
-                    </p>
+                    </div>
                   </div>
 
                   {/* Events Timeline */}

--- a/packages/ui/components/tracking-preview-sheet.tsx
+++ b/packages/ui/components/tracking-preview-sheet.tsx
@@ -319,6 +319,21 @@ export const TrackingPreview = ({
                     <div className="border-t pt-4 space-y-4">
                       <h3 className="text-lg font-semibold">Shipment Details</h3>
 
+                      {/* Shipment ID */}
+                      <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 sm:gap-4 sm:items-center">
+                        <div className="text-sm text-gray-600">Shipment ID</div>
+                        <div className="col-span-2">
+                          <AppLink
+                            className="text-blue-600 hover:text-blue-800 text-sm font-medium inline-flex items-center gap-1"
+                            href={`/shipments/${tracker?.shipment?.id}`}
+                            target="_blank"
+                          >
+                            <span>{tracker?.shipment?.id}</span>
+                            <ExternalLink className="w-3 h-3" />
+                          </AppLink>
+                        </div>
+                      </div>
+
                       {/* Origin/Destination */}
                       <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 sm:gap-4 sm:items-center">
                         <div className="text-sm text-gray-600">Origin/Destination</div>
@@ -351,20 +366,6 @@ export const TrackingPreview = ({
                         </div>
                       )}
 
-                      {/* Link */}
-                      <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 sm:gap-4 sm:items-center">
-                        <div className="text-sm text-gray-600">Link</div>
-                        <div className="col-span-2">
-                          <AppLink
-                            className="text-blue-600 hover:text-blue-800 text-sm font-medium inline-flex items-center gap-1"
-                            href={`/shipments/${tracker?.shipment?.id}`}
-                            target="_blank"
-                          >
-                            <span>{tracker?.shipment?.id}</span>
-                            <ExternalLink className="w-3 h-3" />
-                          </AppLink>
-                        </div>
-                      </div>
                     </div>
                   )}
 

--- a/packages/ui/components/tracking-preview-sheet.tsx
+++ b/packages/ui/components/tracking-preview-sheet.tsx
@@ -168,7 +168,7 @@ export const TrackingPreview = ({
       <Sheet key={key} open={isActive} onOpenChange={(open) => !open && dismiss()}>
         <a ref={link} className="hidden"></a>
         <SheetContent
-          className="w-full sm:w-[800px] sm:max-w-[800px] p-0 shadow-none"
+          className="w-full sm:w-[450px] sm:max-w-[450px] p-0 shadow-none"
           side="right"
         >
           <div className="h-full flex flex-col">
@@ -188,24 +188,27 @@ export const TrackingPreview = ({
               {!isNone(tracker) && (
                 <div className="space-y-6">
                   {/* Carrier Image & Tracking Number */}
-                  <div className="flex items-center justify-center gap-4 mb-4">
-                    <div className="flex-shrink-0">
-                      <CarrierImage
-                        carrier_name={
-                          (tracker?.meta as any)?.carrier || tracker?.carrier_name
-                        }
-                        width={65}
-                        height={65}
-                        text_color={tracker?.tracking_carrier?.config?.text_color}
-                        background={tracker?.tracking_carrier?.config?.brand_color}
-                      />
+                  <div className="text-center mb-4">
+                    <div className="flex justify-center mb-4">
+                      <div className="p-3 bg-gray-50 rounded-xl">
+                        <CarrierImage
+                          carrier_name={
+                            (tracker?.meta as any)?.carrier || tracker?.carrier_name
+                          }
+                          width={48}
+                          height={48}
+                          text_color={tracker?.tracking_carrier?.config?.text_color}
+                          background={tracker?.tracking_carrier?.config?.brand_color}
+                        />
+                      </div>
                     </div>
-                    <div className="text-center">
-                      <div className="flex justify-center items-center gap-1 text-sm text-gray-500 mb-2">
-                        <Package className="h-3.5 w-3.5" />
+
+                    <div className="space-y-1">
+                      <div className="flex justify-center items-center gap-1 text-xs text-gray-500">
+                        <Package className="h-3 w-3" />
                         <span>Tracking Number</span>
                       </div>
-                      <div className="font-mono text-xl font-bold text-gray-900 bg-gray-50 px-4 py-2 rounded">
+                      <div className="font-mono text-sm font-bold text-gray-900 bg-gray-50 px-3 py-1 rounded inline-block">
                         {tracker?.tracking_number}
                       </div>
                     </div>

--- a/packages/ui/components/tracking-preview-sheet.tsx
+++ b/packages/ui/components/tracking-preview-sheet.tsx
@@ -180,36 +180,39 @@ export const TrackingPreview = ({
             <div className="flex-1 overflow-y-auto px-4 py-4">
               {!isNone(tracker) && (
                 <div className="space-y-6">
-                  {/* Carrier Image */}
-                  <div className="text-center pb-4">
-                    <CarrierImage
-                      carrier_name={
-                        (tracker?.meta as any)?.carrier || tracker?.carrier_name
-                      }
-                      width={60}
-                      height={60}
-                      text_color={tracker?.tracking_carrier?.config?.text_color}
-                      background={tracker?.tracking_carrier?.config?.brand_color}
-                    />
-                  </div>
-
-                  {/* Tracking Number */}
-                  <div className="text-center">
-                    <p className="text-lg">
-                      <span className="text-gray-600">Tracking ID</span>{" "}
-                      <strong className="font-bold">{tracker?.tracking_number}</strong>
-                    </p>
+                  {/* Carrier Image & Tracking Number */}
+                  <div className="flex items-center justify-center gap-6 mb-6">
+                    <div className="flex-shrink-0">
+                      <CarrierImage
+                        carrier_name={
+                          (tracker?.meta as any)?.carrier || tracker?.carrier_name
+                        }
+                        width={80}
+                        height={80}
+                        text_color={tracker?.tracking_carrier?.config?.text_color}
+                        background={tracker?.tracking_carrier?.config?.brand_color}
+                      />
+                    </div>
+                    <div className="text-center">
+                      <div className="flex justify-center items-center gap-2 text-sm text-gray-500 mb-3">
+                        <Package className="h-4 w-4" />
+                        <span>Tracking Number</span>
+                      </div>
+                      <div className="font-mono text-xl font-bold text-gray-900 bg-gray-50 px-6 py-3 rounded-lg">
+                        {tracker?.tracking_number}
+                      </div>
+                    </div>
                   </div>
 
                   {/* Estimated Delivery */}
                   {!isNone(tracker?.estimated_delivery) && (
-                    <div className="text-center">
-                      <p className="text-sm text-gray-600 mb-1">
-                        {tracker?.delivered ? "Delivered" : "Estimated Delivery"}
-                      </p>
-                      <p className="text-lg font-bold">
+                    <div className="text-center mb-3">
+                      <div className="text-xs text-gray-500">
+                        {tracker?.delivered ? "Delivered on" : "Estimated Delivery"}
+                      </div>
+                      <div className="font-medium text-gray-900 text-sm">
                         {formatDayDate(tracker!.estimated_delivery as string)}
-                      </p>
+                      </div>
                     </div>
                   )}
 

--- a/packages/ui/components/tracking-preview-sheet.tsx
+++ b/packages/ui/components/tracking-preview-sheet.tsx
@@ -127,7 +127,7 @@ export const TrackingPreview = ({
         {children}
       </TrackingPreviewContext.Provider>
 
-      <Sheet open={isActive} onOpenChange={(open) => !open && dismiss()}>
+      <Sheet key={key} open={isActive} onOpenChange={(open) => !open && dismiss()}>
         <a ref={link} className="hidden"></a>
         <SheetContent
           className="w-full sm:w-[800px] sm:max-w-[800px] p-0 shadow-none"
@@ -164,8 +164,10 @@ export const TrackingPreview = ({
 
                   {/* Tracking Number */}
                   <div className="text-center">
-                    <p className="text-sm text-gray-600 mb-1">Tracking ID</p>
-                    <p className="text-lg font-bold">{tracker?.tracking_number}</p>
+                    <p className="text-lg">
+                      <span className="text-gray-600">Tracking ID</span>{" "}
+                      <strong className="font-bold">{tracker?.tracking_number}</strong>
+                    </p>
                   </div>
 
                   {/* Estimated Delivery */}

--- a/packages/ui/components/tracking-preview-sheet.tsx
+++ b/packages/ui/components/tracking-preview-sheet.tsx
@@ -24,7 +24,18 @@ import {
 import { Button } from "@karrio/ui/components/ui/button";
 import { Input } from "@karrio/ui/components/ui/input";
 import { Label } from "@karrio/ui/components/ui/label";
-import { X, Copy, ExternalLink } from "lucide-react";
+import { Badge } from "@karrio/ui/components/ui/badge";
+import {
+  X,
+  Copy,
+  ExternalLink,
+  CheckCircle,
+  Truck,
+  MapPin,
+  Package,
+  Calendar,
+  Clock
+} from "lucide-react";
 
 type DayEvents = { [k: string]: TrackingEventType[] };
 type TrackingPreviewContextType = {
@@ -121,6 +132,26 @@ export const TrackingPreview = ({
     );
   };
 
+  const getEventIcon = (description?: string) => {
+    const desc = description?.toLowerCase() || "";
+    if (desc.includes("delivered") || desc.includes("parcel locker")) {
+      return <CheckCircle className="h-3 w-3 text-green-600" />;
+    }
+    if (desc.includes("out for delivery")) {
+      return <Truck className="h-3 w-3 text-orange-600" />;
+    }
+    if (desc.includes("arrived") || desc.includes("post office")) {
+      return <MapPin className="h-3 w-3 text-blue-600" />;
+    }
+    if (desc.includes("transit") || desc.includes("departed")) {
+      return <Package className="h-3 w-3 text-gray-600" />;
+    }
+    if (desc.includes("created") || desc.includes("awaiting")) {
+      return <Calendar className="h-3 w-3 text-purple-600" />;
+    }
+    return <Clock className="h-3 w-3 text-gray-500" />;
+  };
+
   return (
     <>
       <TrackingPreviewContext.Provider value={{ previewTracker }}>
@@ -190,34 +221,73 @@ export const TrackingPreview = ({
                   </div>
 
                   {/* Events Timeline */}
-                  <div className="border-t pt-4">
-                    <div className="max-h-80 overflow-y-auto">
-                      <div className="space-y-4">
-                        {Object.entries(computeEvents(tracker as TrackerType)).map(
-                          ([day, events], index) => (
-                            <div key={index} className="space-y-2">
-                              <h3 className="text-sm font-semibold text-gray-900 capitalize">
-                                {day}
-                              </h3>
-                              {events.map((event, index) => (
-                                <div key={index} className="ml-4 space-y-1">
-                                  <div className="flex items-center gap-2">
-                                    <code className="text-xs bg-gray-100 px-2 py-1 rounded">
-                                      {event.time}
-                                    </code>
-                                    <span className="text-xs font-medium text-gray-700">
-                                      {event.location}
-                                    </span>
+                  <div className="border-t pt-4 space-y-4">
+                    <h3 className="text-lg font-semibold">Tracking Timeline</h3>
+                    <div className="max-h-96 overflow-y-auto">
+                      {Object.entries(computeEvents(tracker as TrackerType)).map(
+                        ([day, events], dayIndex) => (
+                          <div key={dayIndex} className="border-b border-gray-100 last:border-b-0">
+                            {/* Date Header */}
+                            <div className="bg-blue-50 px-4 py-3 border-b border-blue-100">
+                              <div className="flex items-center gap-2">
+                                <Calendar className="h-3 w-3 text-blue-600" />
+                                <div>
+                                  <h3 className="text-sm font-medium text-gray-900 capitalize">{day}</h3>
+                                  <p className="text-xs text-gray-500">{events.length} events</p>
+                                </div>
+                              </div>
+                            </div>
+
+                            {/* Events */}
+                            <div className="relative">
+                              {events.map((event, eventIndex) => (
+                                <div key={eventIndex} className="relative">
+                                  {/* Timeline line */}
+                                  {eventIndex < events.length - 1 && (
+                                    <div className="absolute left-6 top-10 bottom-0 w-px bg-gray-200" />
+                                  )}
+
+                                  <div className="flex gap-3 p-3 hover:bg-gray-50 transition-colors">
+                                    {/* Timeline dot with icon */}
+                                    <div className="flex-shrink-0 relative z-10 mt-0.5">
+                                      <div className="w-5 h-5 bg-white border border-gray-300 rounded-full flex items-center justify-center">
+                                        {getEventIcon(event.description || undefined)}
+                                      </div>
+                                    </div>
+
+                                    {/* Event content */}
+                                    <div className="flex-1 min-w-0">
+                                      <div className="flex items-start justify-between gap-2 mb-1">
+                                        <div className="flex-1">
+                                          <Badge
+                                            variant="outline"
+                                            className="text-xs font-mono bg-blue-50 text-blue-700 border-blue-200 mb-2"
+                                          >
+                                            {event.time}
+                                          </Badge>
+
+                                          {event.location && (
+                                            <div className="flex items-center gap-1 mb-2">
+                                              <MapPin className="h-2.5 w-2.5 text-gray-400" />
+                                              <span className="text-sm font-medium text-gray-600">
+                                                {event.location}
+                                              </span>
+                                            </div>
+                                          )}
+
+                                          <p className="text-sm text-gray-800 leading-relaxed">
+                                            {event.description}
+                                          </p>
+                                        </div>
+                                      </div>
+                                    </div>
                                   </div>
-                                  <p className="text-xs text-gray-600 ml-4">
-                                    {event.description}
-                                  </p>
                                 </div>
                               ))}
                             </div>
-                          ),
-                        )}
-                      </div>
+                          </div>
+                        ),
+                      )}
                     </div>
                   </div>
 


### PR DESCRIPTION
# Refactor Tracker Preview Modal to Sheet

## Overview
Migrated the tracker preview modal to a modern sheet component that slides in from the right side, improving user experience and design consistency.

## Changes Made
- Replaced modal with slide-in sheet component from the right side
- Updated trackers list page to use the new tracking-preview-sheet component
- Styled events timeline section to match the main tracking page design
- Improved carrier image and tracking number presentation
- Added status icons to status badges for better visual clarity
- Fixed tracking number alignment issues
- Optimized sheet width and layout for better content display
- Enhanced mobile responsiveness with refactored shipment details layout
- Replaced generic link label with shipment ID
- Repositioned shipment ID to the top for better information hierarchy

## Notes
- Used shadcn/ui components for design system consistency
- Maintained existing functionality while improving presentation
- Enhanced mobile responsiveness across different screen sizes