### PR TITLE
fix(sdk): coerce bytearray to bytes in process_request payload

### DIFF
--- a/modules/sdk/karrio/core/utils/helpers.py
+++ b/modules/sdk/karrio/core/utils/helpers.py
@@ -174,7 +174,7 @@ def process_request(
         if raw is None:
             payload = {}
         elif isinstance(raw, (bytes, bytearray)):
-            payload = dict(data=raw)
+            payload = dict(data=bytes(raw))
         elif isinstance(raw, str):
             payload = dict(data=raw.encode("utf-8"))
         else:


### PR DESCRIPTION
## Bug

`sdk-tests` CI job is failing on every new PR after mypy 2.0 was picked up by the runner:

\`\`\`
modules/sdk/karrio/core/utils/helpers.py:177: error: Dict entry 0 has incompatible type "str": "bytes | bytearray"; expected "str": "bytes"  [dict-item]
\`\`\`

## Root Cause

`payload` is annotated `dict[str, bytes]` (line 171), but the `isinstance(raw, (bytes, bytearray))` branch assigns the narrowed `bytes | bytearray`:

\`\`\`python
payload: dict[str, bytes] = {}
...
elif isinstance(raw, (bytes, bytearray)):
    payload = dict(data=raw)  # bytearray is not bytes
\`\`\`

mypy 1.x accepted this; mypy 2.0 (now installed by `bin/setup-sdk-env`) does not.

## Fix

One-line coercion to satisfy the declared type:

\`\`\`python
payload = dict(data=bytes(raw))
\`\`\`

`bytes(bytes_instance)` is a cheap no-op-equivalent and `bytes(bytearray)` produces equivalent bytes. Downstream `urllib.request.Request` requires bytes-like data anyway, so behavior is unchanged.

## Tests

- Type fix verified against the exact mypy 2.0 error reported in CI logs (`sdk-tests (3.12)` job 75188611968).
- No behavior change for any caller path (bytes / bytearray / str / dict / fallback).

## Why a separate PR

Spotted while CI was failing on an unrelated docs PR (#1080). Splitting this out so it can land independently and unblock all open PRs.