### PR TITLE
fix: configure log colors

### DIFF
--- a/apps/api/karrio/server/settings/base.py
+++ b/apps/api/karrio/server/settings/base.py
@@ -643,6 +643,7 @@ LOG_LEVEL = "DEBUG" if DEBUG else config("LOG_LEVEL", default="INFO")
 DJANGO_LOG_LEVEL = "INFO" if DEBUG else config("DJANGO_LOG_LEVEL", default="WARNING")
 LOG_FILE_DIR = config("LOG_DIR", default=WORK_DIR)
 LOG_FILE_NAME = os.path.join(LOG_FILE_DIR, "debug.log")
+LOG_COLORIZE = config("LOG_COLORIZE", default=True, cast=bool)
 DRF_TRACKING_ADMIN_LOG_READONLY = True
 
 # Option to use Loguru (default: True)
@@ -728,6 +729,7 @@ if USE_LOGURU:
             log_file=LOG_FILE_NAME,
             intercept_django=True,
             enqueue=True,  # Thread-safe async logging
+            colorize=LOG_COLORIZE,
         )
     except ImportError as e:
         # Note: Using print here as Loguru failed to load

--- a/modules/core/karrio/server/core/logging.py
+++ b/modules/core/karrio/server/core/logging.py
@@ -55,6 +55,7 @@ def get_django_log_config():
             "log_file": getattr(settings, "LOG_FILE_NAME", None),
             "log_dir": getattr(settings, "LOG_FILE_DIR", None),
             "debug": getattr(settings, "DEBUG", False),
+            "colorize": getattr(settings, "LOG_COLORIZE", True),
         }
     except Exception:
         # Fallback to environment variables
@@ -63,6 +64,8 @@ def get_django_log_config():
             "log_file": os.getenv("LOG_FILE_NAME"),
             "log_dir": os.getenv("LOG_DIR"),
             "debug": os.getenv("DEBUG_MODE", "False").lower() in ("true", "1", "yes"),
+            "colorize": os.getenv("LOG_COLORIZE", "True").lower()
+            in ("true", "1", "yes"),
         }
 
 
@@ -159,6 +162,7 @@ def setup_django_loguru(
     intercept_django: bool = True,
     serialize: bool = False,
     enqueue: bool = True,
+    colorize: Optional[bool] = None,
 ):
     """
     Set up Loguru for Django with optimal configuration.
@@ -169,6 +173,7 @@ def setup_django_loguru(
         intercept_django: Whether to intercept Django's logging (recommended)
         serialize: Whether to serialize logs as JSON
         enqueue: Whether to use async logging (recommended for Django)
+        colorize: Whether to colorize console logs
 
     This function should be called in Django settings after LOGGING configuration.
     """
@@ -179,14 +184,15 @@ def setup_django_loguru(
     config = get_django_log_config()
     log_level = level or config["level"]
     debug_mode = config["debug"]
+    colorize = config["colorize"] if colorize is None else colorize
     log_format = get_log_format(debug_mode)
 
-    # Add console handler with colors
+    # Add console handler
     _logger.add(
         sys.stderr,
         format=log_format,
         level=log_level,
-        colorize=True,
+        colorize=colorize,
         diagnose=debug_mode,
         backtrace=True,
         enqueue=enqueue,

--- a/modules/sdk/karrio/core/utils/logger.py
+++ b/modules/sdk/karrio/core/utils/logger.py
@@ -39,6 +39,15 @@ def get_log_format() -> str:
     )
 
 
+def get_log_colorize() -> bool:
+    """Check if console log colorization is enabled."""
+    return os.getenv("KARRIO_LOG_COLORIZE", os.getenv("LOG_COLORIZE", "True")).lower() in (
+        "true",
+        "1",
+        "yes",
+    )
+
+
 def should_log_to_file() -> bool:
     """Check if logging to file is enabled."""
     return os.getenv("KARRIO_LOG_FILE", "").strip() != ""
@@ -55,6 +64,7 @@ def configure_logger(
     log_file: Optional[str] = None,
     diagnose: Optional[bool] = None,
     backtrace: Optional[bool] = None,
+    colorize: Optional[bool] = None,
     serialize: bool = False,
     enqueue: bool = False,
 ):
@@ -66,6 +76,7 @@ def configure_logger(
         log_file: Path to log file (if None, will check KARRIO_LOG_FILE env var)
         diagnose: Whether to enable diagnostic mode with variable values
         backtrace: Whether to enable backtrace on exceptions
+        colorize: Whether to colorize console logs
         serialize: Whether to serialize logs as JSON
         enqueue: Whether to use async logging (thread-safe)
 
@@ -73,6 +84,7 @@ def configure_logger(
         KARRIO_LOG_LEVEL: Set the logging level (default: INFO)
         KARRIO_LOG_FORMAT: Custom log format string
         KARRIO_LOG_FILE: Path to log file for file output
+        KARRIO_LOG_COLORIZE: Enable console log colorization (default: True)
         KARRIO_LOG_ROTATION: Log rotation setting (default: "500 MB")
         KARRIO_LOG_RETENTION: Log retention setting (default: "10 days")
         KARRIO_LOG_DIAGNOSE: Enable diagnostic mode (default: False)
@@ -84,6 +96,7 @@ def configure_logger(
     # Determine configuration from environment or parameters
     log_level = level or get_log_level()
     log_format = get_log_format()
+    colorize = get_log_colorize() if colorize is None else colorize
 
     if diagnose is None:
         diagnose = os.getenv("KARRIO_LOG_DIAGNOSE", "False").lower() in (
@@ -104,7 +117,7 @@ def configure_logger(
         sys.stderr,
         format=log_format,
         level=log_level,
-        colorize=True,
+        colorize=colorize,
         diagnose=diagnose,
         backtrace=backtrace,
         enqueue=enqueue,


### PR DESCRIPTION
## Summary

- add LOG_COLORIZE server env setting
- pass colorize through Django Loguru setup
- add SDK KARRIO_LOG_COLORIZE support, falling back to LOG_COLORIZE
- keep colored logs enabled by default

## Impact

Set LOG_COLORIZE=false to disable ANSI-colored server console logs. Set KARRIO_LOG_COLORIZE=false for standalone SDK logs.

## Validation

- python3 -m py_compile apps/api/karrio/server/settings/base.py modules/core/karrio/server/core/logging.py modules/sdk/karrio/core/utils/logger.py
- git diff --check

Server/SDK test wrappers not run: local .venv/karrio is missing, so karrio command/env unavailable.