### PR TITLE
fix: scope MD5 PASSWORD_HASHERS override to test runs only

### DIFF
--- a/apps/api/karrio/server/settings/base.py
+++ b/apps/api/karrio/server/settings/base.py
@@ -374,13 +374,7 @@ DATABASES = {
     }
 }
 
-# Speed up test suite: use fast MD5 hasher instead of bcrypt/PBKDF2
-# This only applies when running `manage.py test` — production is unaffected
-import sys as _sys
-if "test" in _sys.argv or "karrio" in _sys.argv[0]:
-    PASSWORD_HASHERS = [
-        "django.contrib.auth.hashers.MD5PasswordHasher",
-    ]
+TEST_RUNNER = "karrio.server.test_runner.KarrioTestRunner"
 
 if config("DATABASE_URL", default=None):
     db_from_env = dj_database_url.config(

--- a/apps/api/karrio/server/test_runner.py
+++ b/apps/api/karrio/server/test_runner.py
@@ -1,0 +1,13 @@
+from django.conf import settings
+from django.test.runner import DiscoverRunner
+
+
+class KarrioTestRunner(DiscoverRunner):
+    """Custom Django test runner that overrides settings for the test suite."""
+
+    def setup_test_environment(self, **kwargs):
+        super().setup_test_environment(**kwargs)
+        # Speed up tests with a fast hasher (PBKDF2 is intentionally slow).
+        settings.PASSWORD_HASHERS = [
+            "django.contrib.auth.hashers.MD5PasswordHasher",
+        ]


### PR DESCRIPTION
refs https://github.com/orgs/karrioapi/discussions/1094

## Bug

After upgrading past `2026.1.22`, existing users can't log in to the dashboard, and new users have their passwords stored as MD5.

## Root Cause

The test-only `PASSWORD_HASHERS` override in [`settings/base.py`](https://github.com/karrioapi/karrio/blob/main/apps api/karrio/server/settings/base.py#L377-L383) (added in 2026.1.22, commit `f19fe206e`) fires in production because its second predicate matches the install path:

```python
if "test" in _sys.argv or "karrio" in _sys.argv[0]:
```

In `karrio/server`, gunicorn's `sys.argv[0]` is `/karrio/venv/bin/gunicorn` - which contains "karrio". The override fires unconditionally.

## Fix

Replace the argv predicate with a custom `TEST_RUNNER` that sets `PASSWORD_HASHERS` in `setup_test_environment`. Django loads `TEST_RUNNER` only during `karrio test` (the test management command), so production is never affected and the test-suite perf win from `f19fe206e` is preserved.

## Tests

Couldn't run the full suite locally. Relying on this PR's `karrio-tests` workflow.

## Notes

Already MD5-hashed users (created on any `2026.1.22+` deploy) will be locked out by this fix the same way PBKDF2 users were locked out by the original bug. Worth shipping a release that appends `MD5PasswordHasher` to `PASSWORD_HASHERS`.