### PR TITLE
test(studio): render-smoke + CI workflow + visual baseline scaffold

### DIFF
--- a/.github/workflows/studio-e2e.yml
+++ b/.github/workflows/studio-e2e.yml
@@ -1,0 +1,94 @@
+name: studio-e2e
+
+# Run on every push and on PRs touching Studio source or its E2E specs.
+# The mocked `studio` Playwright project does NOT require a Django backend or
+# Postgres — it intercepts all API calls at the Playwright route level.
+on:
+  push:
+    paths:
+      - "apps/studio/**"
+      - "packages/e2e/tests/studio/**"
+      - "packages/e2e/helpers/studio.ts"
+      - "packages/e2e/playwright.config.ts"
+      - ".github/workflows/studio-e2e.yml"
+  pull_request:
+    paths:
+      - "apps/studio/**"
+      - "packages/e2e/tests/studio/**"
+      - "packages/e2e/helpers/studio.ts"
+      - "packages/e2e/playwright.config.ts"
+      - ".github/workflows/studio-e2e.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  studio-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: "npm"
+          cache-dependency-path: apps/studio/package-lock.json
+
+      # Install Studio app dependencies (standalone lockfile, no turborepo).
+      - name: Install Studio deps
+        working-directory: apps/studio
+        run: npm ci
+
+      # Build the Studio app so the dev server can serve the compiled output.
+      # `vite build` produces apps/studio/dist (client) + .output/server (SSR).
+      - name: Build Studio
+        working-directory: apps/studio
+        run: npm run build
+
+      # Install Playwright + Chromium only (mocked suite only needs one browser).
+      - name: Install Playwright browsers
+        working-directory: packages/e2e
+        run: |
+          npm ci
+          npx playwright install chromium --with-deps
+
+      # Start the Studio dev server in the background and wait for it.
+      # We use `npm run dev` (vite dev) instead of the built server so hot-reload
+      # is available; the mocked suite doesn't care which mode the server is in.
+      - name: Start Studio dev server
+        working-directory: apps/studio
+        run: npm run dev &
+        env:
+          PORT: 3003
+
+      - name: Wait for Studio to be ready
+        run: |
+          for i in $(seq 1 30); do
+            curl -sf http://localhost:3003 && break || true
+            echo "Waiting for Studio ($i/30)..."
+            sleep 2
+          done
+          curl -sf http://localhost:3003 || (echo "Studio never became ready" && exit 1)
+
+      # Run the mocked `studio` Playwright project.
+      # No KARRIO_LIVE or Django API needed — all API calls are intercepted.
+      - name: Run Studio E2E (mocked)
+        working-directory: packages/e2e
+        run: npx playwright test --project=studio --reporter=github,html
+        env:
+          KARRIO_STUDIO_URL: http://localhost:3003
+          CI: "true"
+
+      # Upload the HTML report so failures are inspectable via the Actions UI.
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: studio-playwright-report
+          path: packages/e2e/playwright-report/
+          retention-days: 14

--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -34,9 +34,11 @@ export default defineConfig({
     // Karrio Studio (TanStack Start app, apps/studio). Authenticated by default
     // via an inline session cookie (the _app routes are guarded); the auth/guard
     // specs override storageState to test the unauthenticated paths.
+    // visual.spec.ts is excluded here — it only runs via the gated studio-visual project.
     {
       name: "studio",
       testMatch: /studio\/.*\.spec\.ts/,
+      testIgnore: /studio\/visual\.spec\.ts/,
       use: {
         ...devices["Desktop Chrome"],
         baseURL: process.env.KARRIO_STUDIO_URL || "http://localhost:3003",
@@ -68,5 +70,59 @@ export default defineConfig({
         baseURL: process.env.KARRIO_STUDIO_URL || "http://localhost:3003",
       },
     },
+    // Karrio Studio visual regression — screenshot baselines for key screens.
+    // Gated behind KARRIO_VISUAL=1 so CI without committed baselines never fails.
+    // Run locally: KARRIO_VISUAL=1 npx playwright test --project=studio-visual
+    // Update baselines: KARRIO_VISUAL=1 npx playwright test --project=studio-visual --update-snapshots
+    ...(process.env.KARRIO_VISUAL === "1"
+      ? [
+          {
+            name: "studio-visual",
+            testMatch: /studio\/visual\.spec\.ts/,
+            use: {
+              ...devices["Desktop Chrome"],
+              baseURL: process.env.KARRIO_STUDIO_URL || "http://localhost:3003",
+              storageState: {
+                cookies: [
+                  {
+                    name: "karrio-studio-session",
+                    value: JSON.stringify({ access: "test-token", refresh: "r", email: "admin@example.com" }),
+                    domain: "localhost",
+                    path: "/",
+                    httpOnly: true,
+                    secure: false,
+                    sameSite: "Lax" as const,
+                    expires: Math.floor(Date.now() / 1000) + 86400,
+                  },
+                ],
+                origins: [],
+              },
+            },
+          },
+          {
+            name: "studio-visual-mobile",
+            testMatch: /studio\/visual\.spec\.ts/,
+            use: {
+              ...devices["Pixel 7"],
+              baseURL: process.env.KARRIO_STUDIO_URL || "http://localhost:3003",
+              storageState: {
+                cookies: [
+                  {
+                    name: "karrio-studio-session",
+                    value: JSON.stringify({ access: "test-token", refresh: "r", email: "admin@example.com" }),
+                    domain: "localhost",
+                    path: "/",
+                    httpOnly: true,
+                    secure: false,
+                    sameSite: "Lax" as const,
+                    expires: Math.floor(Date.now() / 1000) + 86400,
+                  },
+                ],
+                origins: [],
+              },
+            },
+          },
+        ]
+      : []),
   ],
 });

--- a/packages/e2e/tests/studio/render-smoke.spec.ts
+++ b/packages/e2e/tests/studio/render-smoke.spec.ts
@@ -1,0 +1,231 @@
+import { test, expect, type Page, type Route } from "@playwright/test";
+import { ALL_STUDIO_ROUTES, STUDIO_NAV } from "../../helpers/studio";
+
+// Render-smoke: for EVERY studio route, navigate authenticated and assert:
+//   (a) no `pageerror` was emitted during load, and
+//   (b) the route's screen testid renders.
+//
+// This catches "build-green-but-broken" runtime crashes that tsc/vite miss.
+// Example: display.ts crashed with "Cannot read properties of undefined
+// (reading 'split')" on Trackers/Shipments even though the build was green.
+//
+// All API calls are mocked so this spec is self-contained (no Django backend).
+
+const CORS = {
+  "access-control-allow-origin": "*",
+  "access-control-allow-methods": "GET,POST,OPTIONS",
+  "access-control-allow-headers": "authorization,x-org-id,x-test-mode,content-type",
+};
+
+function jsonReply(route: Route, body: unknown): Promise<void> {
+  if (route.request().method() === "OPTIONS") {
+    return route.fulfill({ status: 204, headers: CORS, body: "" });
+  }
+  return route.fulfill({
+    status: 200,
+    headers: { ...CORS, "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const paged = (results: unknown[]) => ({ count: results.length, next: null, previous: null, results });
+const edges = (field: string, nodes: unknown[]) => ({
+  data: { [field]: { edges: nodes.map((node) => ({ node })) } },
+});
+
+// Minimal fixture data — just enough for each screen to render without crashing.
+// Lists need at least one item so data-path code (map/filter/split) is exercised.
+const MOCK_DATA: Record<string, unknown> = {
+  // Ship mode
+  "/v1/shipments": paged([
+    {
+      id: "shp_smoke",
+      status: "purchased",
+      tracking_number: "SMOKE001",
+      selected_rate: { carrier_name: "ups", service: "ups_ground", total_charge: 9.99, currency: "USD", extra_charges: [] },
+      recipient: { person_name: "Test User", city: "New York", state_code: "NY", country_code: "US" },
+      shipper: { person_name: "Shipper", city: "LA", state_code: "CA", country_code: "US" },
+      reference: "SMOKE-REF",
+      created_at: "2026-05-01T10:00:00Z",
+    },
+  ]),
+  "/v1/trackers": paged([
+    {
+      id: "trk_smoke",
+      tracking_number: "SMOKE_TRK001",
+      carrier_name: "ups",
+      status: "in_transit",
+      estimated_delivery: "2026-06-01",
+      events: [{ description: "Departed", location: "Newark, NJ", date: "2026-05-28", time: "11:00" }],
+    },
+  ]),
+  "/v1/orders": paged([
+    { id: "ord_smoke", order_id: "ORD-001", source: "shopify", status: "unfulfilled", created_at: "2026-05-01T10:00:00Z",
+      shipping_to: { person_name: "Test", city: "NYC", country_code: "US" },
+      line_items: [{ id: "li_1", title: "Widget", quantity: 1, sku: "WGT-1", unfulfilled_quantity: 1 }] },
+  ]),
+  "/v1/pickups": paged([
+    { id: "pck_smoke", carrier_name: "ups", confirmation_number: "PU123", pickup_date: "2026-06-01",
+      ready_time: "09:00", closing_time: "17:00", address: { city: "Brooklyn", country_code: "US" } },
+  ]),
+  "/v1/connections": paged([
+    { id: "con_smoke", carrier_name: "ups", carrier_id: "ups_prod", display_name: "UPS Production",
+      enabled: true, test_mode: false, capabilities: ["rating", "shipping", "tracking"] },
+  ]),
+  "/v1/carrier_connections": paged([]),
+  "/v1/rules": paged([
+    { id: "rl_smoke", name: "Default rule", status: "active", priority: 1 },
+  ]),
+  "/v1/addresses": paged([
+    { id: "adr_smoke", person_name: "Test User", city: "Brooklyn", state_code: "NY", country_code: "US",
+      address_line1: "123 Main St", postal_code: "11201", residential: false },
+  ]),
+  "/v1/parcels": paged([
+    { id: "pcl_smoke", packaging_type: "BOX", weight: 2, weight_unit: "KG",
+      length: 20, width: 15, height: 10, dimension_unit: "CM" },
+  ]),
+  "/v1/products": paged([
+    { id: "prod_smoke", sku: "SKU-001", title: "Test Product", description: "A widget",
+      weight: 0.5, weight_unit: "KG", quantity: 100, variant_id: "v1" },
+  ]),
+  "/v1/documents": paged([
+    { id: "doc_smoke", template_name: "invoice", carrier_name: "ups",
+      related_object_id: "shp_smoke", document_format: "PDF", created_at: "2026-05-01T10:00:00Z" },
+  ]),
+  "/v1/manifests": paged([
+    { id: "mf_smoke", carrier_name: "ups", reference: "MAN-001", shipment_count: 3,
+      created_at: "2026-05-01T10:00:00Z", manifest_url: "http://example.com/m.pdf" },
+  ]),
+  "/v1/batches/operations": paged([
+    { id: "bat_smoke", status: "completed", resource_type: "shipments", total: 5,
+      created_at: "2026-05-01T10:00:00Z" },
+  ]),
+  // Build mode
+  "/v1/apps": paged([
+    { id: "shopify", name: "Shopify", vendor: "Karrio", description: "Sync orders.", installed: true, status: "connected" },
+  ]),
+  "/v1/plugins": paged([
+    { id: "ups", name: "UPS", vendor: "Karrio", description: "Rate, label, track.", installed: true, version: "2026.5.1", tags: ["Carrier"] },
+  ]),
+  "/v1/mcp": {
+    status: "running", url: "https://mcp.karrio.io/test", version: "v2026.5.1",
+    stats: { tools: 1, clients: 1, calls_24h: "1k", p99: "100ms" },
+    tools: [{ name: "list_shipments", description: "List shipments", requests: 100, p99: "80ms" }],
+    clients: [{ id: "claude", name: "Claude Desktop", connected: true, calls: 10 }],
+    invocations: [],
+  },
+  "/v1/webhooks": paged([
+    { id: "wh_smoke", url: "https://example.com/hook", enabled: true,
+      events: ["shipment_purchased"], description: "Test webhook" },
+  ]),
+  "/v1/api_keys": paged([
+    { id: "key_smoke", label: "Test Key", key: "sk_test_••••smoke", test_mode: true, created: "2026-05-01" },
+  ]),
+  // Govern mode
+  "/v1/admin": {
+    version: "2026.5.1", tenants: 1, license: "Enterprise",
+    resources: [{ label: "CPU", used: 30, total: 100 }],
+    runtimes: [{ name: "ups", memory: "32MB", calls: 100, p99: "80ms" }],
+  },
+  "/v1/admin/tenants": paged([
+    { id: "tn_smoke", name: "Smoke Tenant", slug: "smoke", members: 1, status: "active", created: "2026-05-01" },
+  ]),
+  "/v1/admin/users": paged([
+    { id: "usr_smoke", name: "Smoke User", email: "smoke@test.io", role: "owner", status: "active" },
+  ]),
+  "/v1/events": paged([
+    { id: "ev_smoke", type: "shipment.purchased", actor: "smoke@test.io", description: "Purchased label", at: "10:00 AM" },
+  ]),
+  "/v1/usage": {
+    plan: "Enterprise", period: "May 2026",
+    metrics: [{ label: "API calls", value: "1k", delta: "+5%" }],
+  },
+};
+
+// GraphQL mock data for screens that use GQL queries.
+const GQL_DATA: Record<string, unknown> = {
+  workflows: edges("workflows", [
+    { id: "wf_smoke", name: "Auto-fulfill", description: "Fulfill paid orders", is_active: true,
+      trigger: "order.paid", action_count: 1 },
+  ]),
+  rate_sheets: edges("rate_sheets", [
+    { id: "rs_smoke", name: "UPS Negotiated", carrier_name: "ups", services_count: 3, is_system: false },
+  ]),
+};
+
+/**
+ * Register all REST and GraphQL mocks on a page so every API call is satisfied
+ * without a live backend. Mocks use route glob patterns; Playwright applies the
+ * last-registered route first, so specific patterns are registered last.
+ */
+async function mockAllApis(page: Page): Promise<void> {
+  // Broad fallback: any unmatched /v1/ call returns an empty paged response.
+  await page.route("**/v1/**", (route) => jsonReply(route, paged([])));
+
+  // GraphQL (workflows / rate sheets)
+  await page.route("**/graphql", (route) => {
+    if (route.request().method() === "OPTIONS") {
+      return route.fulfill({ status: 204, headers: CORS, body: "" });
+    }
+    const q = route.request().postData() ?? "";
+    const field = Object.keys(GQL_DATA).find((f) => q.includes(f));
+    return jsonReply(route, field ? GQL_DATA[field] : { data: {} });
+  });
+
+  // Register specific REST routes (more specific = registered last = wins).
+  // Admin sub-routes must come after the broad /admin match.
+  await page.route("**/v1/admin**", (route) => jsonReply(route, MOCK_DATA["/v1/admin"]));
+  await page.route("**/v1/admin/tenants**", (route) => jsonReply(route, MOCK_DATA["/v1/admin/tenants"]));
+  await page.route("**/v1/admin/users**", (route) => jsonReply(route, MOCK_DATA["/v1/admin/users"]));
+
+  for (const [path, body] of Object.entries(MOCK_DATA)) {
+    // Skip admin paths — already registered above with correct specificity.
+    if (path.startsWith("/v1/admin")) continue;
+    await page.route(`**${path}**`, (route) => jsonReply(route, body));
+  }
+}
+
+// Routes that require extra patience (lazy-loaded chunks or heavier data fetch)
+const SLOW_ROUTES = new Set(["editor", "admin"]);
+
+test.describe("Studio render-smoke", () => {
+  // Iterate ALL routes and assert:
+  //   1. No JS errors emitted via `pageerror`
+  //   2. The route's `screen-<route>` testid becomes visible
+  for (const route of ALL_STUDIO_ROUTES) {
+    test(`/${route} — no crash + screen renders`, async ({ page }) => {
+      const errors: string[] = [];
+      page.on("pageerror", (err) => errors.push(err.message));
+
+      await mockAllApis(page);
+
+      await page.goto(`/${route}`, { waitUntil: "domcontentloaded" });
+
+      // Wait for the screen testid (generous timeout for lazy chunks).
+      const timeout = SLOW_ROUTES.has(route) ? 15_000 : 10_000;
+      await expect(page.getByTestId(`screen-${route}`)).toBeVisible({ timeout });
+
+      // Fail the test if any JS error fired during load.
+      if (errors.length > 0) {
+        throw new Error(`Page errors on /${route}:\n${errors.join("\n")}`);
+      }
+    });
+  }
+});
+
+// Sanity: verify ALL_STUDIO_ROUTES covers every known mode.
+test.describe("Studio render-smoke — route coverage", () => {
+  const expectedModes = Object.keys(STUDIO_NAV);
+
+  test("STUDIO_NAV covers ship, build, govern modes", () => {
+    expect(expectedModes).toContain("ship");
+    expect(expectedModes).toContain("build");
+    expect(expectedModes).toContain("govern");
+  });
+
+  test("ALL_STUDIO_ROUTES is non-empty and matches STUDIO_NAV union", () => {
+    const union = Object.values(STUDIO_NAV).flat();
+    expect(ALL_STUDIO_ROUTES).toEqual(union);
+    expect(ALL_STUDIO_ROUTES.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/e2e/tests/studio/visual.spec.ts
+++ b/packages/e2e/tests/studio/visual.spec.ts
@@ -1,0 +1,110 @@
+import { test, expect, type Page, type Route } from "@playwright/test";
+
+// Visual regression baselines for Karrio Studio key screens.
+//
+// Gated: only runs when KARRIO_VISUAL=1 via the `studio-visual` / `studio-visual-mobile`
+// Playwright projects defined in playwright.config.ts.
+//
+// First run (no committed baselines): run with --update-snapshots to create them.
+//   KARRIO_VISUAL=1 npx playwright test --project=studio-visual --update-snapshots
+//
+// Subsequent CI runs without baselines: the studio-visual project is excluded from
+// the config entirely (conditional spread), so these tests are never discovered.
+//
+// Screenshots are committed to packages/e2e/tests/studio/__snapshots__/ and
+// compared pixel-by-pixel on future runs (threshold: 0.2%).
+
+const CORS = {
+  "access-control-allow-origin": "*",
+  "access-control-allow-methods": "GET,POST,OPTIONS",
+  "access-control-allow-headers": "authorization,x-org-id,x-test-mode,content-type",
+};
+
+function ok(route: Route, body: unknown): Promise<void> {
+  if (route.request().method() === "OPTIONS") {
+    return route.fulfill({ status: 204, headers: CORS, body: "" });
+  }
+  return route.fulfill({
+    status: 200,
+    headers: { ...CORS, "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const paged = (results: unknown[]) => ({ count: results.length, next: null, previous: null, results });
+
+async function setupMocks(page: Page): Promise<void> {
+  await page.route("**/v1/**", (route) => ok(route, paged([])));
+  await page.route("**/v1/shipments**", (route) =>
+    ok(route, paged([
+      {
+        id: "shp_1", status: "purchased", tracking_number: "1Z999AA10123456784",
+        selected_rate: { carrier_name: "ups", service: "ups_ground", total_charge: 12.4, currency: "USD", extra_charges: [] },
+        recipient: { person_name: "Alicia Romero", city: "Brooklyn", state_code: "NY", country_code: "US" },
+        shipper: { person_name: "Daniel K", city: "LA", state_code: "CA", country_code: "US" },
+        reference: "ORDER-001", created_at: "2026-05-01T10:00:00Z",
+      },
+      {
+        id: "shp_2", status: "in_transit", tracking_number: "1231006943",
+        selected_rate: { carrier_name: "dhl", service: "dhl_express", total_charge: 42.8, currency: "USD", extra_charges: [] },
+        recipient: { person_name: "Helmut Strauss", city: "Berlin", country_code: "DE" },
+        reference: "ORDER-002", created_at: "2026-05-02T08:00:00Z",
+      },
+    ]))
+  );
+  await page.route("**/v1/trackers**", (route) =>
+    ok(route, paged([
+      { id: "trk_1", tracking_number: "1Z999AA10123456784", carrier_name: "ups",
+        status: "in_transit", estimated_delivery: "2026-06-01",
+        events: [{ description: "Departed facility", location: "Newark, NJ", date: "2026-05-28", time: "11:00" }] },
+    ]))
+  );
+  await page.route("**/graphql", (route) => {
+    if (route.request().method() === "OPTIONS") return route.fulfill({ status: 204, headers: CORS, body: "" });
+    return ok(route, { data: {} });
+  });
+}
+
+// Screens chosen for visual coverage: Home (dashboard summary), Shipments
+// (data-rich list), and the Build/Apps tile grid. These cover distinct layout
+// archetypes (stats cards, tabbed list, tile grid) while keeping the suite small.
+test.describe("Studio visual baselines", () => {
+  test.beforeEach(async ({ page }) => {
+    await setupMocks(page);
+  });
+
+  test("Home dashboard", async ({ page }) => {
+    await page.goto("/home", { waitUntil: "domcontentloaded" });
+    await expect(page.getByTestId("screen-home")).toBeVisible();
+    await page.waitForLoadState("networkidle");
+    // Mask dynamic values (dates, counts) to avoid flake.
+    await expect(page).toHaveScreenshot("home.png", {
+      maxDiffPixelRatio: 0.002,
+      mask: [page.locator("[data-testid='home-stats']")],
+    });
+  });
+
+  test("Shipments list", async ({ page }) => {
+    await page.goto("/shipments", { waitUntil: "domcontentloaded" });
+    await expect(page.getByTestId("screen-shipments")).toBeVisible();
+    await page.waitForLoadState("networkidle");
+    await expect(page).toHaveScreenshot("shipments.png", {
+      maxDiffPixelRatio: 0.002,
+    });
+  });
+
+  test("Apps tile grid", async ({ page }) => {
+    await page.route("**/v1/apps**", (route) =>
+      ok(route, paged([
+        { id: "shopify", name: "Shopify", vendor: "Karrio", description: "Sync orders.", installed: true, status: "connected" },
+        { id: "zapier", name: "Zapier", vendor: "Karrio", description: "Automate flows.", installed: false, badge: "new" },
+      ]))
+    );
+    await page.goto("/apps", { waitUntil: "domcontentloaded" });
+    await expect(page.getByTestId("screen-apps")).toBeVisible();
+    await page.waitForLoadState("networkidle");
+    await expect(page).toHaveScreenshot("apps.png", {
+      maxDiffPixelRatio: 0.002,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds the test infra & CI hardening layer for Karrio Studio (EBE-93 + EBE-51):

- **render-smoke.spec.ts** — per-route crash detector: navigates every studio route authenticated, asserts no `pageerror` event fired, and confirms the `screen-<route>` testid renders. Catches "build-green-but-broken" runtime crashes (e.g. the recent `display.ts` crash on Trackers/Shipments threw `reading 'split'` even though tsc/build passed).
- **studio-e2e.yml** — GitHub Actions job that builds Studio, starts the dev server, and runs the mocked `studio` Playwright project. No Postgres/Django required. Uploads the HTML report as an artifact.
- **visual.spec.ts** — screenshot baselines for Home, Shipments, and Apps screens (desktop + mobile) gated behind `KARRIO_VISUAL=1` so CI without committed baselines never fails.
- **playwright.config.ts** — additive-only: adds `studio-visual` / `studio-visual-mobile` projects (conditional on `KARRIO_VISUAL`); excludes `visual.spec.ts` from the base `studio` project.

## Changes

| File | Type | Description |
|------|------|-------------|
| `packages/e2e/tests/studio/render-smoke.spec.ts` | new | 30-test crash-detection suite covering all 28 studio routes + 2 coverage sanity checks |
| `packages/e2e/tests/studio/visual.spec.ts` | new | Screenshot baseline spec (Home, Shipments, Apps); gated by `KARRIO_VISUAL=1` |
| `packages/e2e/playwright.config.ts` | modified | Add `studio-visual` + `studio-visual-mobile` projects; exclude `visual.spec.ts` from `studio` project |
| `.github/workflows/studio-e2e.yml` | new | CI job: build Studio → start dev server → run mocked e2e → upload HTML report |

## Verification

`npx playwright test --project=studio --list` (no server needed):

```
[studio] › studio/render-smoke.spec.ts:196:9 › Studio render-smoke › /home — no crash + screen renders
[studio] › studio/render-smoke.spec.ts:196:9 › Studio render-smoke › /shipments — no crash + screen renders
[studio] › studio/render-smoke.spec.ts:196:9 › Studio render-smoke › /trackers — no crash + screen renders
[studio] › studio/render-smoke.spec.ts:196:9 › Studio render-smoke › /orders — no crash + screen renders
[studio] › studio/render-smoke.spec.ts:196:9 › Studio render-smoke › /pickups — no crash + screen renders
[studio] › studio/render-smoke.spec.ts:196:9 › Studio render-smoke › /connections — no crash + screen renders
[studio] › studio/render-smoke.spec.ts:196:9 › Studio render-smoke › /rules — no crash + screen renders
[studio] › studio/render-smoke.spec.ts:196:9 › Studio render-smoke › /addresses — no crash + screen renders
[studio] › studio/render-smoke.spec.ts:196:9 › Studio render-smoke › /parcels — no crash + screen renders
[studio] › studio/render-smoke.spec.ts:196:9 › Studio render-smoke › /products — no crash + screen renders
[studio] › studio/render-smoke.spec.ts:196:9 › Studio render-smoke › /documents — no crash + screen renders
[studio] › studio/render-smoke.spec.ts:196:9 › Studio render-smoke › /manifests — no crash + screen renders
[studio] › studio/render-smoke.spec.ts:196:9 › Studio render-smoke › /batches — no crash + screen renders
[studio] › studio/render-smoke.spec.ts:196:9 › Studio render-smoke › /apps — no crash + screen renders
[studio] › studio/render-smoke.spec.ts:196:9 › Studio render-smoke › /plugins — no crash + screen renders
[studio] › studio/render-smoke.spec.ts:196:9 › Studio render-smoke › /mcp — no crash + screen renders
[studio] › studio/render-smoke.spec.ts:196:9 › Studio render-smoke › /editor — no crash + screen renders
[studio] › studio/render-smoke.spec.ts:196:9 › Studio render-smoke › /webhooks — no crash + screen renders
[studio] › studio/render-smoke.spec.ts:196:9 › Studio render-smoke › /apikeys — no crash + screen renders
[studio] › studio/render-smoke.spec.ts:196:9 › Studio render-smoke › /workflows — no crash + screen renders
[studio] › studio/render-smoke.spec.ts:196:9 › Studio render-smoke › /admin — no crash + screen renders
[studio] › studio/render-smoke.spec.ts:196:9 › Studio render-smoke › /tenants — no crash + screen renders
[studio] › studio/render-smoke.spec.ts:196:9 › Studio render-smoke › /team — no crash + screen renders
[studio] › studio/render-smoke.spec.ts:196:9 › Studio render-smoke › /security — no crash + screen renders
[studio] › studio/render-smoke.spec.ts:196:9 › Studio render-smoke › /audit — no crash + screen renders
[studio] › studio/render-smoke.spec.ts:196:9 › Studio render-smoke › /settings — no crash + screen renders
[studio] › studio/render-smoke.spec.ts:196:9 › Studio render-smoke › /ratesheets — no crash + screen renders
[studio] › studio/render-smoke.spec.ts:196:9 › Studio render-smoke › /usage — no crash + screen renders
[studio] › studio/render-smoke.spec.ts:220:7 › Studio render-smoke — route coverage › STUDIO_NAV covers ship, build, govern modes
[studio] › studio/render-smoke.spec.ts:226:7 › Studio render-smoke — route coverage › ALL_STUDIO_ROUTES is non-empty and matches STUDIO_NAV union
```

Visual gate: `KARRIO_VISUAL=1 npx playwright test --list` shows 6 additional tests (3 screens × desktop + mobile) under `studio-visual` / `studio-visual-mobile`; without the env var, 0 visual tests appear.

TypeScript: `npx tsc --noEmit -p tsconfig.json` reports only the pre-existing `moduleResolution=node10` deprecation warning — no errors in the new files.

https://claude.ai/code/session_01WTSBTow6kbsnwSabzbS5NM

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTSBTow6kbsnwSabzbS5NM)_