### PR TITLE
feat(studio): preferences persistence module + backend sync seam

### DIFF
--- a/apps/studio/src/components/overlays/TweaksPanel.tsx
+++ b/apps/studio/src/components/overlays/TweaksPanel.tsx
@@ -1,19 +1,24 @@
 // TweaksPanel.tsx — self-editable appearance (G1). Accent / density / font /
-// theme, applied live via CSS variables and persisted to localStorage.
+// theme, applied live via CSS variables and persisted via preferences.ts
+// (localStorage + async backend sync via update_user GraphQL mutation).
 import { useState } from "react";
 import { Sheet } from "~/components/ui/Sheet";
 import { Section } from "~/components/ui/detail";
 import {
-  ACCENTS,
   applyAccent,
   applyDensity,
   applyFont,
-  getAccent,
-  getDensity,
-  getFont,
+  applyTheme,
+  loadPrefs,
+  savePrefs,
+  syncToBackend,
   type Density,
   type FontStack,
-} from "~/lib/theme";
+} from "~/lib/karrio/preferences";
+import { useKarrioCtx } from "~/lib/karrio/session";
+
+// Canonical accent palette (kept here so the constant is co-located with the UI).
+export const ACCENTS = ["#8B5CF6", "#3B82F6", "#10B981", "#F97316", "#E11D48"] as const;
 
 export function TweaksPanel({
   open,
@@ -26,9 +31,11 @@ export function TweaksPanel({
   theme: "dark" | "light";
   onTheme: () => void;
 }) {
-  const [accent, setAccent] = useState(getAccent());
-  const [density, setDensity] = useState<Density>(getDensity());
-  const [font, setFont] = useState<FontStack>(getFont());
+  const ctx = useKarrioCtx();
+  const stored = loadPrefs();
+  const [accent, setAccent] = useState(stored.accent);
+  const [density, setDensity] = useState<Density>(stored.density);
+  const [font, setFont] = useState<FontStack>(stored.font_stack);
 
   if (!open) return null;
 
@@ -41,7 +48,14 @@ export function TweaksPanel({
               <button
                 key={t}
                 className={"btn" + (theme === t ? " btn-primary" : "")}
-                onClick={() => theme !== t && onTheme()}
+                onClick={() => {
+                  if (theme !== t) {
+                    applyTheme(t);
+                    savePrefs({ theme: t });
+                    void syncToBackend(ctx, { ...loadPrefs(), theme: t });
+                    onTheme();
+                  }
+                }}
                 data-testid={`tweak-theme-${t}`}
               >
                 {t[0].toUpperCase() + t.slice(1)}
@@ -59,6 +73,8 @@ export function TweaksPanel({
                 onClick={() => {
                   setAccent(c);
                   applyAccent(c);
+                  savePrefs({ accent: c });
+                  void syncToBackend(ctx, { ...loadPrefs(), accent: c });
                 }}
                 data-testid={`tweak-accent-${c.replace("#", "")}`}
                 style={{
@@ -82,6 +98,8 @@ export function TweaksPanel({
               const d = e.target.value as Density;
               setDensity(d);
               applyDensity(d);
+              savePrefs({ density: d });
+              void syncToBackend(ctx, { ...loadPrefs(), density: d });
             }}
             data-testid="tweak-density"
             aria-label="Density"
@@ -100,6 +118,8 @@ export function TweaksPanel({
               const f = e.target.value as FontStack;
               setFont(f);
               applyFont(f);
+              savePrefs({ font_stack: f });
+              void syncToBackend(ctx, { ...loadPrefs(), font_stack: f });
             }}
             data-testid="tweak-font"
             aria-label="Font"

--- a/apps/studio/src/lib/karrio/preferences.ts
+++ b/apps/studio/src/lib/karrio/preferences.ts
@@ -1,0 +1,250 @@
+// preferences.ts — single source of truth for Studio UI preferences.
+//
+// Architecture:
+//   Layer 1 (synchronous): localStorage — offline cache, survives reload,
+//     identical to prior behaviour. All reads/writes go through here first.
+//   Layer 2 (async): Karrio backend — persisted in User.metadata under the
+//     "studio.customization" namespace via the update_user GraphQL mutation.
+//
+// Backend store: User.metadata JSONField on the Karrio User model.
+//   Write: update_user(input: { metadata: { "studio.customization": <prefs> } })
+//   Read:  The OSS UserType query does not expose metadata in its GraphQL
+//          selection set (only email/full_name/is_staff/permissions are returned).
+//          TODO(backend): Add `metadata: JSON` field to UserType so that
+//          loadFromBackend() can hydrate prefs on fresh login without localStorage.
+//          Until then, loadFromBackend() is a documented no-op on reads; the
+//          localStorage cache is the authoritative read source.
+//
+// Usage from components:
+//   import { loadPrefs, savePrefs, syncToBackend } from "~/lib/karrio/preferences";
+//   const prefs = loadPrefs();           // synchronous — always safe
+//   savePrefs({ accent: "#10B981" });    // synchronous + kicks off async sync
+//   await syncToBackend(ctx, prefs);     // explicit flush (e.g. on unload)
+
+import { graphql, type KarrioCtx } from "~/lib/karrio/client";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type Theme = "dark" | "light";
+export type Density = "compact" | "regular" | "comfy";
+export type FontStack = "Inter" | "IBM Plex" | "System";
+
+/** All Studio appearance / layout preferences. */
+export type Preferences = {
+  theme: Theme;
+  accent: string;
+  density: Density;
+  font_stack: FontStack;
+  /** Reserved for future panel/layout configuration (sidebar width, pane splits, etc.) */
+  layout?: Record<string, unknown>;
+};
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_PREFERENCES: Readonly<Preferences> = {
+  theme: "dark",
+  accent: "#8B5CF6",
+  density: "regular",
+  font_stack: "Inter",
+};
+
+// ---------------------------------------------------------------------------
+// localStorage keys (kept stable for backwards compat with prior theme.ts)
+// ---------------------------------------------------------------------------
+
+const LS_KEYS = {
+  theme:    "karrio-theme",
+  accent:   "karrio-accent",
+  density:  "karrio-density",
+  fontStack: "karrio-font",
+} as const;
+
+// Namespace used when writing into User.metadata on the Karrio backend.
+export const BACKEND_META_KEY = "studio.customization";
+
+// ---------------------------------------------------------------------------
+// localStorage helpers
+// ---------------------------------------------------------------------------
+
+function lsGet(key: string): string | null {
+  try {
+    return typeof localStorage !== "undefined" ? localStorage.getItem(key) : null;
+  } catch {
+    return null;
+  }
+}
+
+function lsSet(key: string, value: string): void {
+  try {
+    if (typeof localStorage !== "undefined") localStorage.setItem(key, value);
+  } catch {
+    // Silently ignore (e.g. private browsing with storage disabled).
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API — synchronous layer (localStorage)
+// ---------------------------------------------------------------------------
+
+/** Load preferences from localStorage, falling back to defaults. */
+export function loadPrefs(): Preferences {
+  return {
+    theme:      (lsGet(LS_KEYS.theme) as Theme)         || DEFAULT_PREFERENCES.theme,
+    accent:     lsGet(LS_KEYS.accent)                   || DEFAULT_PREFERENCES.accent,
+    density:    (lsGet(LS_KEYS.density) as Density)     || DEFAULT_PREFERENCES.density,
+    font_stack: (lsGet(LS_KEYS.fontStack) as FontStack) || DEFAULT_PREFERENCES.font_stack,
+  };
+}
+
+/** Persist a partial preferences update to localStorage. Returns the new full prefs. */
+export function savePrefs(patch: Partial<Preferences>): Preferences {
+  const current = loadPrefs();
+  const next: Preferences = { ...current, ...patch };
+
+  if (patch.theme      !== undefined) lsSet(LS_KEYS.theme, next.theme);
+  if (patch.accent     !== undefined) lsSet(LS_KEYS.accent, next.accent);
+  if (patch.density    !== undefined) lsSet(LS_KEYS.density, next.density);
+  if (patch.font_stack !== undefined) lsSet(LS_KEYS.fontStack, next.font_stack);
+
+  return next;
+}
+
+// ---------------------------------------------------------------------------
+// DOM appliers — apply prefs live via CSS variables / data attributes
+// ---------------------------------------------------------------------------
+
+const FONT_STACKS: Record<FontStack, string> = {
+  Inter:      `"Inter", -apple-system, sans-serif`,
+  "IBM Plex": `"IBM Plex Sans", "Inter", sans-serif`,
+  System:     `-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif`,
+};
+
+export function applyPrefsToDOM(prefs: Preferences): void {
+  if (typeof document === "undefined") return;
+  const root = document.documentElement;
+  root.setAttribute("data-theme", prefs.theme);
+  root.style.setProperty("--accent", prefs.accent);
+  root.dataset.density = prefs.density;
+  root.style.setProperty("--font-sans", FONT_STACKS[prefs.font_stack]);
+}
+
+/** Apply a single field immediately (no save). */
+export function applyTheme(theme: Theme): void {
+  if (typeof document !== "undefined")
+    document.documentElement.setAttribute("data-theme", theme);
+}
+
+export function applyAccent(accent: string): void {
+  if (typeof document !== "undefined")
+    document.documentElement.style.setProperty("--accent", accent);
+}
+
+export function applyDensity(density: Density): void {
+  if (typeof document !== "undefined")
+    document.documentElement.dataset.density = density;
+}
+
+export function applyFont(font: FontStack): void {
+  if (typeof document !== "undefined")
+    document.documentElement.style.setProperty("--font-sans", FONT_STACKS[font]);
+}
+
+// ---------------------------------------------------------------------------
+// Backend adapter — async sync layer (Karrio User.metadata)
+// ---------------------------------------------------------------------------
+
+// GraphQL mutation — writes the full preferences blob into User.metadata under
+// the BACKEND_META_KEY namespace. Karrio's process_dictionaries_mutations helper
+// merges dict keys, so other metadata keys are preserved.
+const UPDATE_USER_PREFS_MUTATION = `
+  mutation UpdateUserPreferences($data: UpdateUserInput!) {
+    update_user(input: $data) {
+      user {
+        email
+      }
+      errors {
+        field
+        messages
+      }
+    }
+  }
+`;
+
+type UpdateUserResponse = {
+  update_user: {
+    user: { email: string } | null;
+    errors: Array<{ field: string; messages: string[] }> | null;
+  };
+};
+
+/**
+ * Flush the given preferences to the Karrio backend (User.metadata).
+ *
+ * Writes to `User.metadata["studio.customization"]`. Fails silently if the
+ * user is not authenticated (ctx.token absent) — localStorage remains the
+ * source of truth in that case.
+ */
+export async function syncToBackend(
+  ctx: KarrioCtx,
+  prefs: Preferences,
+): Promise<void> {
+  if (!ctx.token) return; // unauthenticated — localStorage only
+
+  try {
+    await graphql<UpdateUserResponse>(ctx, UPDATE_USER_PREFS_MUTATION, {
+      data: {
+        metadata: { [BACKEND_META_KEY]: prefs },
+      },
+    });
+  } catch {
+    // Sync failure is non-fatal. The user's local settings remain applied;
+    // they will re-sync on next successful write.
+  }
+}
+
+/**
+ * Load preferences from the Karrio backend into localStorage.
+ *
+ * LIMITATION: The OSS `UserType` GraphQL selection does not expose the
+ * `metadata` field. Until `metadata: JSON` is added to the `user` query
+ * response in `karrio/server/graph/schemas/base/types.py` (UserType class),
+ * this function is a no-op and localStorage remains the primary read source.
+ *
+ * TODO(backend): Expose `metadata` on UserType, then implement:
+ *   const data = await graphql<{ user: { metadata: Record<string, unknown> } }>(
+ *     ctx, `query { user { metadata } }`,
+ *   );
+ *   const remote = data.user?.metadata?.[BACKEND_META_KEY] as Partial<Preferences> | undefined;
+ *   if (remote) savePrefs(remote);
+ */
+export async function loadFromBackend(
+  _ctx: KarrioCtx,
+): Promise<Preferences> {
+  // No-op: returns the current localStorage-cached prefs.
+  // When the TODO above is resolved, replace this body with the remote fetch.
+  return loadPrefs();
+}
+
+// ---------------------------------------------------------------------------
+// Convenience — save + apply + async sync in one call
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply a preference patch: persists to localStorage, applies to DOM immediately,
+ * and fires-and-forgets an async sync to the backend.
+ *
+ * Pass `ctx` from `useKarrioCtx()` when called inside a React component.
+ */
+export function applyAndSavePrefs(
+  patch: Partial<Preferences>,
+  ctx?: KarrioCtx,
+): Preferences {
+  const next = savePrefs(patch);
+  applyPrefsToDOM(next);
+  if (ctx) void syncToBackend(ctx, next);
+  return next;
+}

--- a/apps/studio/src/lib/studio-state.ts
+++ b/apps/studio/src/lib/studio-state.ts
@@ -9,8 +9,9 @@
 // Mapping of Studio-native state onto existing Karrio surfaces:
 //
 //   Customization (theme/accent/density/font/layout)
-//     → Karrio workspace config / user metadata (metafields)
-//       hooks: @karrio/hooks/workspace-config, @karrio/hooks/metadata
+//     → User.metadata["studio.customization"] on the Karrio backend.
+//       localStorage is the synchronous cache; async sync via update_user
+//       GraphQL mutation. See ~/lib/karrio/preferences.ts for full details.
 //
 //   Agent sessions / runs / messages
 //     → Karrio metafields namespaced under `studio.agents.*`
@@ -29,17 +30,21 @@ export const STUDIO_NS = {
   mcp: "studio.mcp",
 } as const;
 
-export type Customization = {
-  theme: "dark" | "light";
-  accent: string;
-  density: "compact" | "regular" | "comfy";
-  font_stack: "Inter" | "IBM Plex" | "System";
-  layout?: Record<string, unknown>;
-};
+// Customization types and defaults are now owned by ~/lib/karrio/preferences.ts
+// (single source of truth). Re-exported here for backwards compatibility with
+// any imports that reference studio-state.ts directly.
+export type {
+  Preferences as Customization,
+  Theme,
+  Density,
+  FontStack,
+} from "~/lib/karrio/preferences";
 
-export const DEFAULT_CUSTOMIZATION: Customization = {
-  theme: "dark",
-  accent: "#8B5CF6",
-  density: "regular",
-  font_stack: "Inter",
-};
+export {
+  DEFAULT_PREFERENCES as DEFAULT_CUSTOMIZATION,
+  loadPrefs,
+  savePrefs,
+  applyAndSavePrefs,
+  syncToBackend,
+  loadFromBackend,
+} from "~/lib/karrio/preferences";


### PR DESCRIPTION
## Summary

Introduces `apps/studio/src/lib/karrio/preferences.ts` as the single source of truth for Studio UI preferences (theme, accent, density, font, layout). Preferences are persisted synchronously to localStorage (offline cache, identical prior behaviour) and flushed asynchronously to the Karrio backend via the `update_user` GraphQL mutation.

## Backend Persistence — Real or Seam?

**Real write path, documented read seam.**

- **Write (real):** `User.metadata["studio.customization"]` via the existing `update_user(input: { metadata: { ... } })` GraphQL mutation. This field (`User.metadata: JSONField`) and mutation (`UpdateUserInput.metadata`) already exist in the OSS backend with no migrations needed.
- **Read (documented seam / no-op):** The OSS `UserType` GraphQL selection does not expose `metadata` (only `email`, `full_name`, `is_staff`, `permissions` etc.). `loadFromBackend()` is therefore a well-documented no-op that falls through to localStorage. A `TODO(backend)` comment in `preferences.ts` pinpoints exactly what to add (`metadata: JSON` on `UserType`) to make round-trip sync work.

## Changes

| File | Change |
|---|---|
| `apps/studio/src/lib/karrio/preferences.ts` | **New** — typed `Preferences` module: `loadPrefs`, `savePrefs`, `applyPrefsToDOM`, `syncToBackend`, `loadFromBackend`, `applyAndSavePrefs`. All types defined here (no `types.ts` / `hooks.ts` edits). |
| `apps/studio/src/lib/studio-state.ts` | Updated to import/re-export from `preferences.ts`; removes inline `Customization` type + `DEFAULT_CUSTOMIZATION` (now in preferences.ts); backward-compat re-exports preserved. |
| `apps/studio/src/components/overlays/TweaksPanel.tsx` | Wired to `preferences.ts`; removes direct `localStorage` / `theme.ts` calls; all `data-testid`, `data-density`, and `--accent` CSS variable behaviours required by `tweaks.spec.ts` are preserved exactly. |

## Verification

- `npx tsc --noEmit` — no new errors (only the pre-existing `routeTree.gen` + route type errors that exist on the base branch)
- `npx vite build` — succeeds: 279 modules transformed, client + SSR bundles built cleanly
- All `data-testid` attributes asserted by `packages/e2e/tests/studio/tweaks.spec.ts` are present: `tweaks-panel`, `tweak-theme-{dark,light}`, `tweak-accent-{color}`, `tweak-density`, `tweak-font`
- CSS variable `--accent` and `data-density` attribute behaviour unchanged

https://claude.ai/code/session_01WTSBTow6kbsnwSabzbS5NM

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTSBTow6kbsnwSabzbS5NM)_