### PR TITLE
feat(studio): agent definitions + MCP server config persistence

### DIFF
--- a/apps/studio/src/lib/karrio/agents.ts
+++ b/apps/studio/src/lib/karrio/agents.ts
@@ -1,0 +1,297 @@
+// agents.ts — Typed store for agent definitions (F2) and MCP server configs (F3).
+//
+// Persistence: localStorage (single source of truth for OSS).
+//
+// Backend-adapter seam: the `BackendAdapter` interface below is the integration
+// point for a future Karrio API endpoint (e.g. /v1/studio/agents).
+// A `localStorageAdapter` is the default — it is the only real implementation
+// today because no OSS backend endpoint exists for agent or MCP server configs.
+// Replace `defaultAdapter` with a REST adapter once the backend ships.
+//
+// MCP execution seam: connecting to / invoking an external MCP server requires
+// a backend proxy that does not exist in OSS Karrio. The `McpServerConfig`
+// records stored here are *configuration only*. The `connectionStatus` field
+// is set to "config-only" to make this explicit.
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Transport variants for MCP server connections. */
+export type McpTransport = "stdio" | "sse" | "http";
+
+/**
+ * A user-managed MCP server configuration entry.
+ * Storing this config does NOT establish a live connection; actual MCP
+ * execution requires a backend proxy (not available in OSS Karrio today).
+ */
+export type McpServerConfig = {
+  /** Unique identifier (UUID v4, client-generated). */
+  id: string;
+  /** Human-readable label for the server. */
+  name: string;
+  /** Transport type: stdio (local process) | sse / http (remote). */
+  transport: McpTransport;
+  /**
+   * For stdio: the command to run (e.g. "npx @my/mcp-server").
+   * For sse/http: the URL (e.g. "https://mcp.example.com/events").
+   */
+  endpoint: string;
+  /** Environment variables to pass to the server process (stdio only). */
+  env: Record<string, string>;
+  /** ISO timestamp when the record was created. */
+  createdAt: string;
+  /** ISO timestamp of last edit. */
+  updatedAt: string;
+  /**
+   * Always "config-only" in OSS — this library stores configuration only.
+   * A backend proxy would be required to actually connect and return "ok" or
+   * "error". Never display a fabricated "connected" status.
+   *
+   * TODO(F3-exec): replace with a real status once a backend proxy exists.
+   */
+  connectionStatus: "config-only";
+};
+
+/** Available LLM models for agent definitions. */
+export type AgentModel =
+  | "claude-opus-4-8"
+  | "claude-sonnet-4-6"
+  | "claude-haiku-3-5"
+  | string;
+
+/** A persisted agent definition (F2). */
+export type AgentDef = {
+  /** Unique identifier (UUID v4, client-generated). */
+  id: string;
+  /** Human-readable display name. */
+  name: string;
+  /** Short description shown in the agents list. */
+  description: string;
+  /** The system prompt sent before user messages. */
+  systemPrompt: string;
+  /** Model identifier to use for this agent. */
+  model: AgentModel;
+  /** Whether this agent is active / surfaced in selectors. */
+  enabled: boolean;
+  /** Tool IDs this agent is allowed to call. */
+  enabledTools: string[];
+  /** ISO timestamp when the record was created. */
+  createdAt: string;
+  /** ISO timestamp of last edit. */
+  updatedAt: string;
+};
+
+// ---------------------------------------------------------------------------
+// Backend-adapter seam (TODO: swap to a REST implementation when backend ships)
+// ---------------------------------------------------------------------------
+
+/**
+ * Adapter interface for agent + MCP config persistence.
+ *
+ * TODO(F2/F3-backend): implement a `restAdapter` using
+ * `restGet` / `restMutate` from ~/lib/karrio/client once the Karrio API
+ * exposes endpoints like /v1/studio/agents and /v1/studio/mcp-servers.
+ * The adapter should accept a `KarrioCtx` and delegate to those endpoints,
+ * falling back to localStorage on network errors so the UI stays usable.
+ */
+interface BackendAdapter {
+  // --- Agent definitions ---
+  listAgents(): Promise<AgentDef[]>;
+  saveAgent(agent: AgentDef): Promise<AgentDef>;
+  deleteAgent(id: string): Promise<void>;
+
+  // --- MCP server configs ---
+  listMcpServers(): Promise<McpServerConfig[]>;
+  saveMcpServer(server: McpServerConfig): Promise<McpServerConfig>;
+  deleteMcpServer(id: string): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// localStorage implementation
+// ---------------------------------------------------------------------------
+
+const LS_AGENTS_KEY = "karrio-studio:agents";
+const LS_MCP_KEY = "karrio-studio:mcp-servers";
+
+function readJson<T>(key: string, fallback: T): T {
+  try {
+    const raw = typeof localStorage !== "undefined" ? localStorage.getItem(key) : null;
+    return raw ? (JSON.parse(raw) as T) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function writeJson<T>(key: string, value: T): void {
+  try {
+    if (typeof localStorage !== "undefined") {
+      localStorage.setItem(key, JSON.stringify(value));
+    }
+  } catch {
+    /* storage may be unavailable in SSR or private-browsing contexts */
+  }
+}
+
+const localStorageAdapter: BackendAdapter = {
+  listAgents: () => Promise.resolve(readJson<AgentDef[]>(LS_AGENTS_KEY, [])),
+
+  saveAgent: (agent) => {
+    const existing = readJson<AgentDef[]>(LS_AGENTS_KEY, []);
+    const idx = existing.findIndex((a) => a.id === agent.id);
+    const next =
+      idx >= 0
+        ? existing.map((a) => (a.id === agent.id ? agent : a))
+        : [...existing, agent];
+    writeJson(LS_AGENTS_KEY, next);
+    return Promise.resolve(agent);
+  },
+
+  deleteAgent: (id) => {
+    const next = readJson<AgentDef[]>(LS_AGENTS_KEY, []).filter((a) => a.id !== id);
+    writeJson(LS_AGENTS_KEY, next);
+    return Promise.resolve();
+  },
+
+  listMcpServers: () => Promise.resolve(readJson<McpServerConfig[]>(LS_MCP_KEY, [])),
+
+  saveMcpServer: (server) => {
+    const existing = readJson<McpServerConfig[]>(LS_MCP_KEY, []);
+    const idx = existing.findIndex((s) => s.id === server.id);
+    const next =
+      idx >= 0
+        ? existing.map((s) => (s.id === server.id ? server : s))
+        : [...existing, server];
+    writeJson(LS_MCP_KEY, next);
+    return Promise.resolve(server);
+  },
+
+  deleteMcpServer: (id) => {
+    const next = readJson<McpServerConfig[]>(LS_MCP_KEY, []).filter((s) => s.id !== id);
+    writeJson(LS_MCP_KEY, next);
+    return Promise.resolve();
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Active adapter (swap this to a REST adapter when the backend ships)
+// ---------------------------------------------------------------------------
+
+const defaultAdapter: BackendAdapter = localStorageAdapter;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function uuid(): string {
+  if (typeof crypto !== "undefined" && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+// ---------------------------------------------------------------------------
+// Public API — agent definitions
+// ---------------------------------------------------------------------------
+
+export const agents = {
+  list: (): Promise<AgentDef[]> => defaultAdapter.listAgents(),
+
+  create: (
+    fields: Omit<AgentDef, "id" | "createdAt" | "updatedAt">,
+  ): Promise<AgentDef> => {
+    const agent: AgentDef = { ...fields, id: uuid(), createdAt: now(), updatedAt: now() };
+    return defaultAdapter.saveAgent(agent);
+  },
+
+  update: (
+    id: string,
+    fields: Partial<Omit<AgentDef, "id" | "createdAt">>,
+  ): Promise<AgentDef> => {
+    const current = readJson<AgentDef[]>(LS_AGENTS_KEY, []).find((a) => a.id === id);
+    if (!current) return Promise.reject(new Error(`Agent not found: ${id}`));
+    const updated: AgentDef = { ...current, ...fields, id, updatedAt: now() };
+    return defaultAdapter.saveAgent(updated);
+  },
+
+  remove: (id: string): Promise<void> => defaultAdapter.deleteAgent(id),
+};
+
+// ---------------------------------------------------------------------------
+// Public API — MCP server configs
+// ---------------------------------------------------------------------------
+
+export const mcpServers = {
+  list: (): Promise<McpServerConfig[]> => defaultAdapter.listMcpServers(),
+
+  create: (
+    fields: Omit<McpServerConfig, "id" | "createdAt" | "updatedAt" | "connectionStatus">,
+  ): Promise<McpServerConfig> => {
+    const server: McpServerConfig = {
+      ...fields,
+      id: uuid(),
+      createdAt: now(),
+      updatedAt: now(),
+      connectionStatus: "config-only",
+    };
+    return defaultAdapter.saveMcpServer(server);
+  },
+
+  update: (
+    id: string,
+    fields: Partial<Omit<McpServerConfig, "id" | "createdAt" | "connectionStatus">>,
+  ): Promise<McpServerConfig> => {
+    const current = readJson<McpServerConfig[]>(LS_MCP_KEY, []).find((s) => s.id === id);
+    if (!current) return Promise.reject(new Error(`MCP server not found: ${id}`));
+    const updated: McpServerConfig = {
+      ...current,
+      ...fields,
+      id,
+      updatedAt: now(),
+      connectionStatus: "config-only",
+    };
+    return defaultAdapter.saveMcpServer(updated);
+  },
+
+  remove: (id: string): Promise<void> => defaultAdapter.deleteMcpServer(id),
+};
+
+// ---------------------------------------------------------------------------
+// Default agent definitions seeded on first use
+// ---------------------------------------------------------------------------
+
+const SEED_AGENTS: Array<Omit<AgentDef, "id" | "createdAt" | "updatedAt">> = [
+  {
+    name: "Carrier Connector Builder",
+    description: "Scaffolds and edits Karrio carrier connector files end-to-end.",
+    systemPrompt:
+      "You are an expert Karrio contributor. Help the user build carrier connector modules " +
+      "(mappers, providers, schemas, tests) following the Karrio SDK extension pattern " +
+      "(`bin/cli sdk add-extension`). Always use `import karrio.lib as lib`.",
+    model: "claude-opus-4-8",
+    enabled: true,
+    enabledTools: ["scaffold_connector", "read_file", "write_file", "run_tests"],
+  },
+  {
+    name: "Shipping Assistant",
+    description: "Answers shipping questions and calls Karrio APIs on your behalf.",
+    systemPrompt:
+      "You are a helpful shipping operations assistant. You can look up shipments, " +
+      "create trackers, and fetch rates using the Karrio API. Be concise and accurate.",
+    model: "claude-sonnet-4-6",
+    enabled: true,
+    enabledTools: ["list_shipments", "track_shipment", "get_rates"],
+  },
+];
+
+/** Seed default agents if the store is empty. Call once at app init. */
+export async function seedDefaultAgents(): Promise<void> {
+  const existing = await agents.list();
+  if (existing.length === 0) {
+    await Promise.all(SEED_AGENTS.map((a) => agents.create(a)));
+  }
+}

--- a/apps/studio/src/screens/build/EditorScreen.tsx
+++ b/apps/studio/src/screens/build/EditorScreen.tsx
@@ -1,11 +1,13 @@
 // EditorScreen.tsx — Build › Editor (D4). Agent-first plugin IDE: sessions ·
 // assistant chat · files. The chat is wired to the assistant server fn (F1).
-import { useRef, useState } from "react";
+// Agent definitions are persisted via ~/lib/karrio/agents (F2).
+import { useEffect, useRef, useState } from "react";
 import { Icon } from "~/components/ui/icons";
 import { sendAssistantMessage } from "~/server/assistant";
+import { agents, seedDefaultAgents, type AgentDef, type AgentModel } from "~/lib/karrio/agents";
 
 type Msg = { id: string; role: "user" | "assistant"; content: string };
-type Sess = { id: string; title: string; plugin: string };
+type Sess = { id: string; title: string; plugin: string; agentId?: string };
 
 // Standard Karrio connector extension layout (mirrors `bin/cli sdk add-extension`).
 function connectorFiles(slug: string): string[] {
@@ -30,6 +32,263 @@ function connectorFiles(slug: string): string[] {
 
 const FILES = ["__init__.py", "settings.py", "mapper.py", "providers/rate.py", "providers/tracking.py", "units.py"];
 
+// ---------------------------------------------------------------------------
+// Agent form (create / edit)
+// ---------------------------------------------------------------------------
+
+type AgentFormProps = {
+  initial?: AgentDef;
+  onSave: (agent: AgentDef) => void;
+  onCancel: () => void;
+};
+
+function AgentForm({ initial, onSave, onCancel }: AgentFormProps) {
+  const [name, setName] = useState(initial?.name ?? "");
+  const [description, setDescription] = useState(initial?.description ?? "");
+  const [systemPrompt, setSystemPrompt] = useState(initial?.systemPrompt ?? "");
+  const [model, setModel] = useState<AgentModel>(initial?.model ?? "claude-sonnet-4-6");
+  const [enabled, setEnabled] = useState(initial?.enabled ?? true);
+  const [toolsRaw, setToolsRaw] = useState((initial?.enabledTools ?? []).join(", "));
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSave = async () => {
+    if (!name.trim()) {
+      setError("Name is required.");
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      const enabledTools = toolsRaw
+        .split(",")
+        .map((t) => t.trim())
+        .filter(Boolean);
+      const saved = initial
+        ? await agents.update(initial.id, { name, description, systemPrompt, model, enabled, enabledTools })
+        : await agents.create({ name, description, systemPrompt, model, enabled, enabledTools });
+      onSave(saved);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to save agent.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="card" style={{ padding: 16, display: "flex", flexDirection: "column", gap: 10 }} data-testid="agent-form">
+      <div style={{ fontWeight: 600, marginBottom: 4 }}>{initial ? "Edit agent" : "New agent"}</div>
+      {error && <div style={{ color: "var(--danger, #e53)", fontSize: 12 }}>{error}</div>}
+
+      <label style={{ display: "flex", flexDirection: "column", gap: 4, fontSize: 12, fontWeight: 500 }}>
+        Name *
+        <input
+          className="field-input"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="e.g. Carrier Connector Builder"
+          data-testid="agent-form-name"
+        />
+      </label>
+
+      <label style={{ display: "flex", flexDirection: "column", gap: 4, fontSize: 12, fontWeight: 500 }}>
+        Description
+        <input
+          className="field-input"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="Short description shown in the sidebar"
+          data-testid="agent-form-description"
+        />
+      </label>
+
+      <label style={{ display: "flex", flexDirection: "column", gap: 4, fontSize: 12, fontWeight: 500 }}>
+        System prompt
+        <textarea
+          className="field-input"
+          style={{ minHeight: 80, resize: "vertical" }}
+          value={systemPrompt}
+          onChange={(e) => setSystemPrompt(e.target.value)}
+          placeholder="Instructions prepended before every user message…"
+          data-testid="agent-form-prompt"
+        />
+      </label>
+
+      <label style={{ display: "flex", flexDirection: "column", gap: 4, fontSize: 12, fontWeight: 500 }}>
+        Model
+        <select
+          className="select-sm"
+          style={{ height: 30 }}
+          value={model}
+          onChange={(e) => setModel(e.target.value as AgentModel)}
+          data-testid="agent-form-model"
+        >
+          <option value="claude-opus-4-8">Opus 4.8</option>
+          <option value="claude-sonnet-4-6">Sonnet 4.6</option>
+          <option value="claude-haiku-3-5">Haiku 3.5</option>
+        </select>
+      </label>
+
+      <label style={{ display: "flex", flexDirection: "column", gap: 4, fontSize: 12, fontWeight: 500 }}>
+        Enabled tools <span className="muted" style={{ fontWeight: 400 }}>(comma-separated IDs)</span>
+        <input
+          className="field-input"
+          value={toolsRaw}
+          onChange={(e) => setToolsRaw(e.target.value)}
+          placeholder="e.g. scaffold_connector, read_file, run_tests"
+          data-testid="agent-form-tools"
+        />
+      </label>
+
+      <label style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 12, fontWeight: 500, cursor: "pointer" }}>
+        <input
+          type="checkbox"
+          checked={enabled}
+          onChange={(e) => setEnabled(e.target.checked)}
+          data-testid="agent-form-enabled"
+        />
+        Enabled
+      </label>
+
+      <div style={{ display: "flex", gap: 8, marginTop: 4 }}>
+        <button
+          className="btn btn-primary btn-sm"
+          onClick={() => void handleSave()}
+          disabled={saving}
+          data-testid="agent-form-save"
+        >
+          {saving ? "Saving…" : "Save"}
+        </button>
+        <button className="btn btn-sm" onClick={onCancel} data-testid="agent-form-cancel">
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Agents panel (list + add/edit/delete)
+// ---------------------------------------------------------------------------
+
+type AgentsPanelProps = {
+  onSelectAgent: (agent: AgentDef) => void;
+  selectedAgentId?: string;
+};
+
+function AgentsPanel({ onSelectAgent, selectedAgentId }: AgentsPanelProps) {
+  const [agentList, setAgentList] = useState<AgentDef[]>([]);
+  const [editing, setEditing] = useState<AgentDef | "new" | null>(null);
+
+  const load = () =>
+    agents
+      .list()
+      .then(setAgentList)
+      .catch(() => undefined);
+
+  useEffect(() => {
+    void seedDefaultAgents().then(load);
+  }, []);
+
+  const handleSaved = (agent: AgentDef) => {
+    setEditing(null);
+    void load();
+    onSelectAgent(agent);
+  };
+
+  const handleDelete = async (id: string) => {
+    await agents.remove(id);
+    await load();
+  };
+
+  if (editing !== null) {
+    return (
+      <AgentForm
+        initial={editing === "new" ? undefined : editing}
+        onSave={handleSaved}
+        onCancel={() => setEditing(null)}
+      />
+    );
+  }
+
+  return (
+    <>
+      <div className="editor-pane-head">
+        <span>Agents</span>
+        <button
+          className="btn btn-sm"
+          style={{ marginLeft: "auto" }}
+          onClick={() => setEditing("new")}
+          data-testid="agent-add"
+        >
+          <Icon.Plus size={12} /> New
+        </button>
+      </div>
+      <div className="editor-pane-body" data-testid="agent-list">
+        {agentList.length === 0 && (
+          <div className="state-row" style={{ padding: "12px 16px", fontSize: 12 }}>No agents yet.</div>
+        )}
+        {agentList.map((a) => (
+          <div
+            key={a.id}
+            className={"session-item" + (a.id === selectedAgentId ? " active" : "")}
+            style={{ position: "relative" }}
+            data-testid={`agent-item-${a.id}`}
+          >
+            <span
+              className="session-dot"
+              style={{ background: a.enabled ? "var(--green, #16a34a)" : "var(--muted-fg, #aaa)" }}
+            />
+            <button
+              style={{
+                flex: 1,
+                textAlign: "left",
+                background: "none",
+                border: "none",
+                cursor: "pointer",
+                minWidth: 0,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+                padding: 0,
+                fontSize: "inherit",
+              }}
+              onClick={() => onSelectAgent(a)}
+              title={a.description || a.name}
+            >
+              {a.name}
+            </button>
+            <div style={{ display: "flex", gap: 4, flexShrink: 0 }}>
+              <button
+                className="btn btn-sm"
+                style={{ padding: "1px 5px", fontSize: 10 }}
+                onClick={(e) => { e.stopPropagation(); setEditing(a); }}
+                data-testid={`agent-edit-${a.id}`}
+                title="Edit agent"
+              >
+                <Icon.Settings size={11} />
+              </button>
+              <button
+                className="btn btn-sm"
+                style={{ padding: "1px 5px", fontSize: 10 }}
+                onClick={(e) => { e.stopPropagation(); void handleDelete(a.id); }}
+                data-testid={`agent-delete-${a.id}`}
+                title="Delete agent"
+              >
+                <Icon.X size={11} />
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main EditorScreen
+// ---------------------------------------------------------------------------
+
 export function EditorScreen() {
   const [sessions, setSessions] = useState<Sess[]>([{ id: "s1", title: "New carrier: Acme Express", plugin: "acme" }]);
   const [activeSession, setActiveSession] = useState("s1");
@@ -37,11 +296,13 @@ export function EditorScreen() {
     { id: "m0", role: "assistant", content: "Hi! Describe the carrier or plugin you want to build and I'll scaffold it." },
   ]);
   const [draft, setDraft] = useState("");
-  const [model, setModel] = useState("claude-opus-4-8");
+  const [model, setModel] = useState<AgentModel>("claude-opus-4-8");
   const [mode, setMode] = useState("agent");
   const [sending, setSending] = useState(false);
   const [files, setFiles] = useState<string[]>(FILES);
   const [scaffoldSlug, setScaffoldSlug] = useState("");
+  const [selectedAgentId, setSelectedAgentId] = useState<string | undefined>();
+  const [leftTab, setLeftTab] = useState<"sessions" | "agents">("sessions");
   const streamRef = useRef<HTMLDivElement>(null);
 
   const scaffold = () => {
@@ -82,30 +343,65 @@ export function EditorScreen() {
     setMessages([{ id: "m0", role: "assistant", content: "New session. What should we build?" }]);
   };
 
+  const handleSelectAgent = (agent: AgentDef) => {
+    setSelectedAgentId(agent.id);
+    setModel(agent.model as AgentModel);
+    setLeftTab("sessions");
+  };
+
   return (
     <div className="editor" data-testid="screen-editor">
+      {/* Left pane: tabbed Sessions / Agents */}
       <div className="editor-pane">
-        <div className="editor-pane-head">
-          <span>Agent sessions</span>
-          <button className="btn btn-sm" style={{ marginLeft: "auto" }} onClick={newSession} data-testid="editor-new-session">
-            <Icon.Plus size={12} /> New
+        <div style={{ display: "flex", borderBottom: "1px solid var(--border)" }}>
+          <button
+            className={"tab" + (leftTab === "sessions" ? " active" : "")}
+            style={{ flex: 1, borderRadius: 0, border: "none", fontSize: 12 }}
+            onClick={() => setLeftTab("sessions")}
+            data-testid="left-tab-sessions"
+          >
+            Sessions
+          </button>
+          <button
+            className={"tab" + (leftTab === "agents" ? " active" : "")}
+            style={{ flex: 1, borderRadius: 0, border: "none", fontSize: 12 }}
+            onClick={() => setLeftTab("agents")}
+            data-testid="left-tab-agents"
+          >
+            Agents
           </button>
         </div>
-        <div className="editor-pane-body" data-testid="editor-sessions">
-          {sessions.map((s) => (
-            <div
-              key={s.id}
-              className={"session-item" + (s.id === activeSession ? " active" : "")}
-              onClick={() => setActiveSession(s.id)}
-              data-testid={`editor-session-${s.id}`}
-            >
-              <span className="session-dot" />
-              <span style={{ minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{s.title}</span>
+
+        {leftTab === "sessions" && (
+          <>
+            <div className="editor-pane-head">
+              <span>Sessions</span>
+              <button className="btn btn-sm" style={{ marginLeft: "auto" }} onClick={newSession} data-testid="editor-new-session">
+                <Icon.Plus size={12} /> New
+              </button>
             </div>
-          ))}
-        </div>
+            <div className="editor-pane-body" data-testid="editor-sessions">
+              {sessions.map((s) => (
+                <div
+                  key={s.id}
+                  className={"session-item" + (s.id === activeSession ? " active" : "")}
+                  onClick={() => setActiveSession(s.id)}
+                  data-testid={`editor-session-${s.id}`}
+                >
+                  <span className="session-dot" />
+                  <span style={{ minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{s.title}</span>
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+
+        {leftTab === "agents" && (
+          <AgentsPanel onSelectAgent={handleSelectAgent} selectedAgentId={selectedAgentId} />
+        )}
       </div>
 
+      {/* Chat pane */}
       <div className="chat">
         <div className="chat-stream" ref={streamRef} data-testid="editor-messages">
           {messages.map((m) => (
@@ -130,7 +426,7 @@ export function EditorScreen() {
             aria-label="Message the assistant"
           />
           <div className="composer-bar">
-            <select className="select-sm" value={model} onChange={(e) => setModel(e.target.value)} aria-label="Model" data-testid="editor-model">
+            <select className="select-sm" value={model} onChange={(e) => setModel(e.target.value as AgentModel)} aria-label="Model" data-testid="editor-model">
               <option value="claude-opus-4-8">Opus 4.8</option>
               <option value="claude-sonnet-4-6">Sonnet 4.6</option>
             </select>
@@ -146,6 +442,7 @@ export function EditorScreen() {
         </div>
       </div>
 
+      {/* Right pane: file tree + scaffold */}
       <div className="editor-pane right">
         <div className="editor-pane-head">Files · {sessions.find((s) => s.id === activeSession)?.plugin}</div>
         <div style={{ display: "flex", gap: 6, padding: "8px 8px 0" }}>

--- a/apps/studio/src/screens/build/McpScreen.tsx
+++ b/apps/studio/src/screens/build/McpScreen.tsx
@@ -1,8 +1,15 @@
-// McpScreen.tsx — Build › MCP (D3). Manage the Karrio MCP server.
-import { useState } from "react";
+// McpScreen.tsx — Build › MCP (D3). Manage the Karrio MCP server + user-defined
+// MCP server configurations (F3). The Karrio server card reflects live API data.
+// User-managed server configs are persisted to localStorage via ~/lib/karrio/agents.
+//
+// IMPORTANT: Actual MCP execution (connecting, invoking tools) is NOT supported
+// in OSS Karrio — there is no backend proxy. All user-added servers show status
+// "config only". Never display a fabricated "connected" or "healthy" status.
+import { useEffect, useState } from "react";
 import { Icon } from "~/components/ui/icons";
 import { PageHeader } from "~/components/ui/primitives";
 import { useMcp } from "~/lib/karrio/hooks";
+import { mcpServers, type McpServerConfig, type McpTransport } from "~/lib/karrio/agents";
 
 function KvStat({ label, value }: { label: string; value: React.ReactNode }) {
   return (
@@ -22,6 +29,217 @@ const CLAUDE_SNIPPET = `{
     }
   }
 }`;
+
+// ---------------------------------------------------------------------------
+// MCP server form (add / edit user-managed servers)
+// ---------------------------------------------------------------------------
+
+type McpServerFormProps = {
+  initial?: McpServerConfig;
+  onSave: (server: McpServerConfig) => void;
+  onCancel: () => void;
+};
+
+function McpServerForm({ initial, onSave, onCancel }: McpServerFormProps) {
+  const [name, setName] = useState(initial?.name ?? "");
+  const [transport, setTransport] = useState<McpTransport>(initial?.transport ?? "stdio");
+  const [endpoint, setEndpoint] = useState(initial?.endpoint ?? "");
+  const [envRaw, setEnvRaw] = useState(
+    initial?.env ? Object.entries(initial.env).map(([k, v]) => `${k}=${v}`).join("\n") : "",
+  );
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const parseEnv = (raw: string): Record<string, string> =>
+    Object.fromEntries(
+      raw
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .map((line) => {
+          const eq = line.indexOf("=");
+          return eq > 0 ? [line.slice(0, eq).trim(), line.slice(eq + 1).trim()] : null;
+        })
+        .filter((pair): pair is [string, string] => pair !== null),
+    );
+
+  const handleSave = async () => {
+    if (!name.trim()) { setError("Name is required."); return; }
+    if (!endpoint.trim()) { setError("Endpoint / command is required."); return; }
+    setSaving(true);
+    setError(null);
+    try {
+      const env = parseEnv(envRaw);
+      const saved = initial
+        ? await mcpServers.update(initial.id, { name, transport, endpoint, env })
+        : await mcpServers.create({ name, transport, endpoint, env });
+      onSave(saved);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to save.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const endpointLabel = transport === "stdio" ? "Command" : "URL";
+  const endpointPlaceholder =
+    transport === "stdio" ? "e.g. npx @my/mcp-server" : "e.g. https://mcp.example.com/events";
+
+  return (
+    <div className="card" style={{ padding: 16, display: "flex", flexDirection: "column", gap: 10 }} data-testid="mcp-server-form">
+      <div style={{ fontWeight: 600, marginBottom: 4 }}>{initial ? "Edit MCP server" : "Add MCP server"}</div>
+      {error && <div style={{ color: "var(--danger, #e53)", fontSize: 12 }}>{error}</div>}
+
+      <label style={{ display: "flex", flexDirection: "column", gap: 4, fontSize: 12, fontWeight: 500 }}>
+        Name *
+        <input className="field-input" value={name} onChange={(e) => setName(e.target.value)} placeholder="e.g. My MCP server" data-testid="mcp-form-name" />
+      </label>
+
+      <label style={{ display: "flex", flexDirection: "column", gap: 4, fontSize: 12, fontWeight: 500 }}>
+        Transport
+        <select className="select-sm" style={{ height: 30 }} value={transport} onChange={(e) => setTransport(e.target.value as McpTransport)} data-testid="mcp-form-transport">
+          <option value="stdio">stdio (local process)</option>
+          <option value="sse">SSE (server-sent events)</option>
+          <option value="http">HTTP (streamable)</option>
+        </select>
+      </label>
+
+      <label style={{ display: "flex", flexDirection: "column", gap: 4, fontSize: 12, fontWeight: 500 }}>
+        {endpointLabel} *
+        <input className="field-input" value={endpoint} onChange={(e) => setEndpoint(e.target.value)} placeholder={endpointPlaceholder} data-testid="mcp-form-endpoint" />
+      </label>
+
+      {transport === "stdio" && (
+        <label style={{ display: "flex", flexDirection: "column", gap: 4, fontSize: 12, fontWeight: 500 }}>
+          Environment variables <span className="muted" style={{ fontWeight: 400 }}>(one KEY=value per line)</span>
+          <textarea
+            className="field-input"
+            style={{ minHeight: 60, resize: "vertical", fontFamily: "var(--font-mono, monospace)", fontSize: 11 }}
+            value={envRaw}
+            onChange={(e) => setEnvRaw(e.target.value)}
+            placeholder={"API_KEY=sk_live_...\nSECRET=..."}
+            data-testid="mcp-form-env"
+          />
+        </label>
+      )}
+
+      <div style={{ padding: "8px 10px", background: "var(--surface-muted, #f5f5f5)", borderRadius: 6, fontSize: 11, color: "var(--muted-fg, #888)" }} data-testid="mcp-form-notice">
+        Configuration only — OSS Karrio does not include an MCP execution proxy. Actual connection and tool invocation require a backend proxy (not yet implemented).
+      </div>
+
+      <div style={{ display: "flex", gap: 8, marginTop: 4 }}>
+        <button className="btn btn-primary btn-sm" onClick={() => void handleSave()} disabled={saving} data-testid="mcp-form-save">
+          {saving ? "Saving…" : "Save"}
+        </button>
+        <button className="btn btn-sm" onClick={onCancel} data-testid="mcp-form-cancel">Cancel</button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// User-managed MCP servers section
+// ---------------------------------------------------------------------------
+
+function UserMcpServers() {
+  const [serverList, setServerList] = useState<McpServerConfig[]>([]);
+  const [editing, setEditing] = useState<McpServerConfig | "new" | null>(null);
+
+  const load = () =>
+    mcpServers
+      .list()
+      .then(setServerList)
+      .catch(() => undefined);
+
+  useEffect(() => { void load(); }, []);
+
+  const handleSaved = (server: McpServerConfig) => {
+    setEditing(null);
+    void load();
+  };
+
+  const handleDelete = async (id: string) => {
+    await mcpServers.remove(id);
+    await load();
+  };
+
+  if (editing !== null) {
+    return (
+      <McpServerForm
+        initial={editing === "new" ? undefined : editing}
+        onSave={handleSaved}
+        onCancel={() => setEditing(null)}
+      />
+    );
+  }
+
+  return (
+    <div className="card card-scroll" data-testid="mcp-user-servers">
+      <div style={{ padding: "12px 16px", borderBottom: "1px solid var(--border)", display: "flex", alignItems: "center", gap: 8 }}>
+        <span style={{ fontWeight: 600, flex: 1 }}>Your MCP servers</span>
+        <button className="btn btn-sm" onClick={() => setEditing("new")} data-testid="mcp-add-server">
+          <Icon.Plus size={12} /> Add
+        </button>
+      </div>
+      {serverList.length === 0 ? (
+        <div className="state-row" style={{ padding: "16px", fontSize: 12 }}>
+          No MCP servers configured. Add one to store its connection details.
+        </div>
+      ) : (
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Transport</th>
+              <th>Endpoint</th>
+              <th>Status</th>
+              <th style={{ textAlign: "right" }}>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {serverList.map((s) => (
+              <tr key={s.id} data-testid={`mcp-server-row-${s.id}`}>
+                <td style={{ fontWeight: 500 }}>{s.name}</td>
+                <td><span className="pill" style={{ background: "var(--surface-muted, #eee)", color: "inherit", fontSize: 10 }}>{s.transport}</span></td>
+                <td className="mono muted" style={{ fontSize: 11, maxWidth: 240, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{s.endpoint}</td>
+                <td>
+                  {/* Honest status: never claim "connected" — no backend proxy in OSS */}
+                  <span className="pill" style={{ background: "var(--surface-muted, #eee)", color: "var(--muted-fg, #888)", fontSize: 10 }} data-testid={`mcp-server-status-${s.id}`}>
+                    config only
+                  </span>
+                </td>
+                <td style={{ textAlign: "right" }}>
+                  <div style={{ display: "flex", gap: 4, justifyContent: "flex-end" }}>
+                    <button
+                      className="btn btn-sm"
+                      style={{ padding: "2px 6px", fontSize: 11 }}
+                      onClick={() => setEditing(s)}
+                      data-testid={`mcp-server-edit-${s.id}`}
+                    >
+                      <Icon.Settings size={11} />
+                    </button>
+                    <button
+                      className="btn btn-sm"
+                      style={{ padding: "2px 6px", fontSize: 11 }}
+                      onClick={() => void handleDelete(s.id)}
+                      data-testid={`mcp-server-delete-${s.id}`}
+                    >
+                      <Icon.X size={11} />
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// McpScreen — top-level
+// ---------------------------------------------------------------------------
 
 export function McpScreen() {
   const { data, isLoading } = useMcp();
@@ -85,6 +303,11 @@ export function McpScreen() {
             ))}
           </tbody>
         </table>
+      </div>
+
+      {/* User-managed MCP server configurations (F3) */}
+      <div style={{ marginBottom: 16 }}>
+        <UserMcpServers />
       </div>
 
       <div className="two-col">


### PR DESCRIPTION
## Summary

Implements F2 (agent definitions) and F3 (MCP server config management) for Karrio Studio. Agent configs and MCP server entries are persisted to localStorage with a clearly documented backend-adapter seam for future REST integration. No fabricated connection status is shown for MCP servers — the UI is honest about being configuration-only in OSS.

## Changes

| File | Change |
|------|--------|
| `apps/studio/src/lib/karrio/agents.ts` | **New** — typed store for `AgentDef` and `McpServerConfig`; localStorage persistence; `BackendAdapter` interface seam (documented TODO for REST); `seedDefaultAgents()` helper |
| `apps/studio/src/screens/build/EditorScreen.tsx` | Wired `AgentsPanel` (create / edit / delete / select) via the store; tabbed left pane (Sessions / Agents); selecting an agent copies its model to the composer |
| `apps/studio/src/screens/build/McpScreen.tsx` | Added `UserMcpServers` section — add / list / edit / remove MCP server configs; "config only" status badge is honest (no backend proxy in OSS Karrio) |

## Persistence and execution honesty

- **Agent definitions**: fully persisted to `localStorage` under key `karrio-studio:agents`. A typed `BackendAdapter` interface is defined and documented so a REST adapter (e.g. `/v1/studio/agents`) can be dropped in later — the `defaultAdapter` variable is the single swap point.
- **MCP server configs**: persisted to `localStorage` under `karrio-studio:mcp-servers`. Connection status is always `"config-only"` — the type system enforces this. No OSS backend proxy exists to actually connect or invoke tools, and the UI communicates this clearly with an explanatory notice in the add-server form and a "config only" pill in the table.

## Verification

- `npx vite build` passes clean: 279 client modules transformed, 124 SSR modules — no errors.
- `npx tsc --noEmit`: zero errors in modified files; 8 pre-existing infrastructure errors (missing `routeTree.gen`, which is a generated file not present until Vite dev server runs).
- All existing `data-testid` attributes from `build.spec.ts` and `editor.spec.ts` are preserved: `mcp-server-card`, `mcp-status`, `mcp-toggle`, `mcp-snippet`, `mcp-copy`, `mcp-tools`, `mcp-invocations`, `mcp-tool-*`, `editor-sessions`, `editor-session-s1`, `editor-new-session`, `editor-messages`, `editor-input`, `editor-send`, `editor-model`, `editor-mode`, `editor-scaffold`, `editor-scaffold-input`, `editor-files`, `msg-user`, `msg-assistant`.

https://claude.ai/code/session_01WTSBTow6kbsnwSabzbS5NM

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTSBTow6kbsnwSabzbS5NM)_