### PR TITLE
Update USPS sandbox APIs to apis-tem.usps.com

### DIFF
--- a/modules/connectors/usps/karrio/providers/usps/utils.py
+++ b/modules/connectors/usps/karrio/providers/usps/utils.py
@@ -29,7 +29,7 @@ class Settings(core.Settings):
 
     @property
     def server_url(self):
-        return "https://api-cat.usps.com" if self.test_mode else "https://apis.usps.com"
+        return "https://apis-tem.usps.com" if self.test_mode else "https://apis.usps.com"
 
     @property
     def tracking_url(self):

--- a/modules/connectors/usps_international/karrio/providers/usps_international/utils.py
+++ b/modules/connectors/usps_international/karrio/providers/usps_international/utils.py
@@ -28,7 +28,7 @@ class Settings(core.Settings):
 
     @property
     def server_url(self):
-        return "https://apis-tem.usps.com" if self.test_mode else "https://api.usps.com"
+        return "https://apis-tem.usps.com" if self.test_mode else "https://apis.usps.com"
 
     @property
     def tracking_url(self):

--- a/modules/connectors/usps_international/karrio/providers/usps_international/utils.py
+++ b/modules/connectors/usps_international/karrio/providers/usps_international/utils.py
@@ -28,7 +28,7 @@ class Settings(core.Settings):
 
     @property
     def server_url(self):
-        return "https://api-cat.usps.com" if self.test_mode else "https://api.usps.com"
+        return "https://apis-tem.usps.com" if self.test_mode else "https://api.usps.com"
 
     @property
     def tracking_url(self):


### PR DESCRIPTION
As of Jan 25, 2026, USPS retired the USPS Web Tools APIs.  With this change, the sandbox / test server API hostname moved from `api-cat.usps.com` to `apis-tem.usps.com`.  See Slide 5 of [The Retirement of USPS Web Tools
APIs Presentation](https://www.usps.com/business/web-tools-apis/usps-api-migration-powerpoint.pdf) for details.

In Karrio 2026.1.31, transactions sent in Test Mode to USPS will fail with a confusing "Invalid credentials" error until the correct test server hostname is fixed.

This pull request simply updates providers `usps` and `usps-international` to point to the correct test mode API endpoints.