### PR TITLE
fix(usps): declare usps_rate_indicator option and price_type connection config

### DIFF
--- a/modules/connectors/usps/karrio/providers/usps/shipment/create.py
+++ b/modules/connectors/usps/karrio/providers/usps/shipment/create.py
@@ -265,7 +265,7 @@ def shipment_request(
                 width=package.width.IN,
                 girth=package.girth.value,
                 mailClass=mail_class,
-                rateIndicator=package.options.usps_rate_indicator.state or "DR",
+                rateIndicator=package.options.usps_rate_indicator.state or "SP",
                 processingCategory=lib.identity(
                     package.options.usps_processing_category.state or "NON_MACHINABLE"
                 ),

--- a/modules/connectors/usps/karrio/providers/usps/units.py
+++ b/modules/connectors/usps/karrio/providers/usps/units.py
@@ -247,6 +247,7 @@ class ShippingOption(lib.Enum):
     usps_carrier_release = lib.OptionEnum("carrierRelease", bool, meta=dict(category="DELIVERY_OPTIONS"))
     usps_physical_signature_required = lib.OptionEnum("physicalSignatureRequired", bool, meta=dict(category="SIGNATURE"))
     usps_price_type = lib.OptionEnum("priceType", lib.units.create_enum("priceType", ["RETAIL", "COMMERCIAL", "CONTRACT"]))
+    usps_rate_indicator = lib.OptionEnum("rateIndicator")
     usps_destination_entry_facility_type = lib.OptionEnum("destinationEntryFacilityType", lib.units.create_enum("destinationEntryFacilityType", ["NONE", "DESTINATION_NETWORK_DISTRIBUTION_CENTER", "DESTINATION_SECTIONAL_CENTER_FACILITY", "DESTINATION_DELIVERY_UNIT", "DESTINATION_SERVICE_HUB"]))
     usps_extra_services = lib.OptionEnum("extraServices", list)
     usps_shipping_filter = lib.OptionEnum("shippingFilter", lib.units.create_enum("shippingFilter", ["PRICE", "SERVICE_STANDARDS"]))

--- a/modules/connectors/usps/karrio/providers/usps/utils.py
+++ b/modules/connectors/usps/karrio/providers/usps/utils.py
@@ -45,6 +45,7 @@ class Settings(core.Settings):
 
 class ConnectionConfig(lib.Enum):
     permit_ZIP = lib.OptionEnum("permit_ZIP")
+    price_type = lib.OptionEnum("price_type")
     permit_number = lib.OptionEnum("permit_number")
     shipping_options = lib.OptionEnum("shipping_options", list)
     shipping_services = lib.OptionEnum("shipping_services", list)

--- a/modules/connectors/usps/tests/usps/test_shipment.py
+++ b/modules/connectors/usps/tests/usps/test_shipment.py
@@ -253,7 +253,7 @@ ShipmentRequest = [
             "mailClass": "LIBRARY_MAIL",
             "mailingDate": "2024-07-28",
             "processingCategory": "NON_MACHINABLE",
-            "rateIndicator": "DR",
+            "rateIndicator": "SP",
             "weight": 44.1,
             "weightUOM": "lb",
             "width": 4.72,


### PR DESCRIPTION
## Summary

USPS contract (NSA) pricing is unreachable through the connector. `usps_rate_indicator` is consumed in the label request and `price_type` is consumed in the rate request, but neither is declared in its enum, so both are silently dropped by the options filter. Labels always ship with the hardcoded `DR` rate indicator, which makes USPS answer "Contract rate not found for request. Published rate returned." and bill published rates instead of the account's contract rates.

## Changes

| File | What changed |
|------|-------------|
| `providers/usps/units.py` | Declare `usps_rate_indicator` in `ShippingOption` |
| `providers/usps/utils.py` | Declare `price_type` in `ConnectionConfig` (read by `rate.py`) |
| `providers/usps/shipment/create.py` | Default label `rateIndicator` `DR` → `SP` (single piece) |
| `tests/usps/test_shipment.py` | Request fixture updated for the new default |

## Verification

Verified against the live USPS API with an EPS account holding contract rates: quotes (`price_type: CONTRACT` connection config) and label postage both return the contract price. All 34 USPS connector tests pass.